### PR TITLE
chore(release): specify repositoryUrl for semantic-release

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -3,6 +3,7 @@
  */
 export default {
   branches: ['main'],
+  repositoryUrl: "git@github.com:snyk/snyk-broker-config.git",
   prepare: ['@semantic-release/npm'],
   publish: ['@semantic-release/npm', '@semantic-release/github'],
 }


### PR DESCRIPTION
This PR fixes issue from semantic-release. We configure to use git protocol instead of https.
```
EGITNOPERMISSION Cannot push to the Git repository
```
https://app.circleci.com/pipelines/github/snyk/snyk-broker-config/24/workflows/78c98ab2-2cb1-4859-8d20-ec4d4dc40fba/jobs/59