### PR TITLE
fix: missing command in oclif manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /node_modules
 oclif.manifest.json
 
-
+tsconfig.tsbuildinfo
 
 yarn.lock
 pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "build": "shx rm -rf dist && tsc -b",
     "lint": "eslint . --ext .ts",
     "test": "node test/run-test.js",
+    "prepack": "oclif manifest",
     "version": "oclif readme && git add README.md",
     "format": "prettier --write '{src,test}/**/*.{js,ts}'"
   },

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -5,21 +5,14 @@ export default {
   branches: ['main'],
   repositoryUrl: 'git@github.com:snyk/snyk-broker-config.git',
   prepare: [
-    '@semantic-release/npm',
-    [
-      // generate oclif.manifest.json
-      '@semantic-release/exec',
-      {
-        prepareCmd: "npx oclif manifest"
-      },
-    ],
     [
       // compile typescript files
       '@semantic-release/exec',
       {
-        prepareCmd: "npm run build"
+        prepareCmd: 'npm run build',
       },
-    ]
+    ],
+    '@semantic-release/npm',
   ],
   publish: ['@semantic-release/npm', '@semantic-release/github'],
 }


### PR DESCRIPTION
This PR fixes the issue with empty oclif manifest publishing to NPM.