### PR TITLE
chore: improve cred sample name

### DIFF
--- a/src/command-helpers/connections/parameters-capture.ts
+++ b/src/command-helpers/connections/parameters-capture.ts
@@ -43,7 +43,7 @@ export const captureConnectionParams = async (
       if (choice === 'CreateNew') {
         const envVarName = await validatedInput(
           {
-            message: `Env Var Name (i.e MY_GITHUB_TOKEN)`,
+            message: `Env Var Name (i.e MY_${key.toLocaleUpperCase()})`,
           },
           ValidationType.ENVVAR,
         )


### PR DESCRIPTION
Example env var name is now based on the connection type being created.