### PR TITLE
fix: display no integrations found error if none found instead of blank

### DIFF
--- a/src/commands/workflows/integrations/get.ts
+++ b/src/commands/workflows/integrations/get.ts
@@ -31,6 +31,9 @@ export default class Workflows extends BaseCommand<typeof Workflows> {
       // const selectedConnectionData = await getConnectionsForDeployment(tenantId, installId, deploymentId)
       const integrations = await getIntegrationsForConnection(tenantId, selectedConnection.id)
       const integrationsList = integrations.data ?? []
+      if (integrationsList.length === 0) {
+        throw new Error(`No Integrations found for connection ${selectedConnection.id} (${selectedConnection.type})`)
+      }
       this.log(printFormattedJSON(integrationsList))
       this.log(ux.colorize('red', 'Connection Integration listing Workflow completed.'))
     } catch (error: any) {


### PR DESCRIPTION
Fixes inconsistent output if no connection integration is found.