### PR TITLE
chore: change circleci context to hybrid team

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ workflows:
           name: Release to GitHub and NPM
           context:
             - nodejs-lib-release
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Run tests
           <<: *filter-main-branch-only


### PR DESCRIPTION
This PR aligns CircleCI context (and don't use deprecated and removed one).