### PR TITLE
feat(release): build standalone installers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,56 @@ jobs:
       - run:
           name: Build package
           command: npm run build
+  build-macos:
+    macos:
+      xcode: 16.4.0
+    resource_class: macos.m1.medium.gen1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build macOS .pkg installers
+          command: |
+            npm run build
+            npm run prepack
+            npm run pack:macos
+      - store_artifacts:
+          path: dist/macos/
+  build-win:
+    macos:
+      xcode: 16.4.0
+    resource_class: macos.m1.medium.gen1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build Windows installers
+          command: |
+            brew install nsis
+            brew install p7zip
+            npm run build
+            npm run prepack
+            npm run pack:win
+      - store_artifacts:
+          path: dist/win32/
+  build-linux:
+    <<: *defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build Linux tarballs
+          command: |
+            sudo apt-get update
+            sudo apt-get install --assume-yes apt-utils
+            npm run build
+            npm run prepack
+            npm run pack:linux
+      - store_artifacts:
+          path: dist/deb/
   install-npm-packages:
     <<: *defaults
     environment:
@@ -114,6 +164,21 @@ workflows:
           name: Run tests
           requires:
             - Install NPM packages
+      - build-macos:
+          name: Build macOS installer
+          requires:
+            - Run tests
+          <<: *filter-non-main-branches
+      - build-win:
+          name: Build Windows installer
+          requires:
+            - Run tests
+          <<: *filter-non-main-branches
+      - build-linux:
+          name: Build Linux tarballs
+          requires:
+            - Run tests
+          <<: *filter-non-main-branches
       - release:
           name: Release to GitHub and NPM
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,26 +164,28 @@ workflows:
           name: Run tests
           requires:
             - Install NPM packages
-      - build-macos:
-          name: Build macOS installer
-          requires:
-            - Run tests
-          <<: *filter-non-main-branches
-      - build-win:
-          name: Build Windows installer
-          requires:
-            - Run tests
-          <<: *filter-non-main-branches
       - build-linux:
           name: Build Linux tarballs
           requires:
             - Run tests
-          <<: *filter-non-main-branches
+          <<: *filter-main-branch-only
+      - build-macos:
+          name: Build macOS installer
+          requires:
+            - Run tests
+          <<: *filter-main-branch-only
+      - build-win:
+          name: Build Windows installer
+          requires:
+            - Run tests
+          <<: *filter-main-branch-only
       - release:
           name: Release to GitHub and NPM
           context:
             - nodejs-lib-release
             - team-hybrid-snyk
           requires:
-            - Run tests
+            - Build Linux tarballs
+            - Build macOS installer
+            - Build Windows installer
           <<: *filter-main-branch-only

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,41 @@
-*-debug.log
-*-error.log
-**/.DS_Store
-/.idea
-/dist
-/tmp
-/node_modules
+#################################
+# Compiled source               #
+#################################
+dist/
+
+#################################
+# Node.js, NPM and oclif files  #
+#################################
+coverage/
+node_modules/
+reports/
+*.tsbuildinfo
+.eslintcache
+.nyc_output
 oclif.manifest.json
 
-tsconfig.tsbuildinfo
+#################################
+# IDE generated files           #
+#################################
+.idea/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
 
-yarn.lock
-pnpm-lock.yaml
+#################################
+# Logs and temp files           #
+#################################
+/tmp
+*.log
+*.tmp
+*~
 
+#################################
+# OS generated files            #
+#################################
+Thumbs.db
+.directory
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -95,7 +95,13 @@
         "description": "Interactive workflows for Deployments, Credentials, Connections and Integrations management"
       }
     },
-    "theme": "theme.json"
+    "theme": "theme.json",
+    "macos": {
+      "identifier": "io.snyk.snyk-broker-config.cli"
+    },
+    "windows": {
+      "name": "Snyk Broker Config CLI"
+    }
   },
   "repository": "snyk/snyk-broker-config",
   "scripts": {
@@ -103,6 +109,9 @@
     "lint": "eslint . --ext .ts",
     "test": "node test/run-test.js",
     "prepack": "oclif manifest",
+    "pack:linux": "oclif pack deb",
+    "pack:macos": "oclif pack macos",
+    "pack:win": "oclif pack win",
     "version": "oclif readme && git add README.md",
     "format": "prettier --write '{src,test}/**/*.{js,ts}'"
   },

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -14,5 +14,23 @@ export default {
     ],
     '@semantic-release/npm',
   ],
-  publish: ['@semantic-release/npm', '@semantic-release/github'],
+  publish: [
+    '@semantic-release/npm',
+    [
+      '@semantic-release/github',
+      {
+        assets: [
+          {
+            path: 'dist/deb/*.deb',
+          },
+          {
+            path: 'dist/macos/*.pkg',
+          },
+          {
+            path: 'dist/win32/*.exe',
+          },
+        ],
+      },
+    ],
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": "src",
     "strict": true,
     "target": "es2022",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "moduleResolution": "node16"
   },
   "include": ["./src/**/*"],


### PR DESCRIPTION
This PR utilizes [release built-in functionality](https://oclif.io/docs/releasing) from oclif and builds standalone installers for:

- macOS: arm64 and x64
- Windows: arm64, x64 and x86
- Linux: arm64, amd64 and armel

The binaries are attached to GitHub release as `assets` via semantic-release.