### PR TITLE
chore: update codeowners - move to Access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/hybrid
+* @snyk/access


### PR DESCRIPTION
This PR updates CODEOWNERS file -> move to Access.