### PR TITLE
chore: set circle CI contexts to access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ workflows:
           name: Snyk Security Scans
           context:
             - nodejs-install
-            - team-hybrid-snyk
+            - platformeng_access
           requires:
             - Install NPM packages
           <<: *filter-non-main-branches
@@ -183,7 +183,7 @@ workflows:
           name: Release to GitHub and NPM
           context:
             - nodejs-lib-release
-            - team-hybrid-snyk
+            - platformeng_access
           requires:
             - Build Linux tarballs
             - Build macOS installer


### PR DESCRIPTION
What this does
- Replaces all references of team hybrid to access in the circle CI context.