### PR TITLE
fix: improve messaging when user fails to auth

### DIFF
--- a/src/api/snyk.ts
+++ b/src/api/snyk.ts
@@ -7,7 +7,21 @@ import {createLogger} from '../utils/logger.js'
 
 const logger = createLogger('snyk-broker-config')
 
-export const validateSnykToken = async (snykToken: string): Promise<void> => {
+interface SelfResponse {
+  data: {
+    id: string;
+    type: "user";
+    attributes: {
+      avatar_url: string;
+      default_org_context: string;
+      email: string;
+      name: string;
+      username: string;
+    }
+  }
+}
+
+export const validateSnykToken = async (snykToken: string): Promise<string> => {
   if (!isValidUUID(snykToken)) {
     throw new Error('Invalid Format.')
   }
@@ -24,6 +38,10 @@ export const validateSnykToken = async (snykToken: string): Promise<void> => {
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+
+    const parsedResponse = JSON.parse(response.body) as SelfResponse;
+    return parsedResponse.data.id;
+
   } catch (error: any) {
     let errorMessage = error
     if (error.includes('401: Unauthorized.')) {

--- a/test/api/snyk.test.ts
+++ b/test/api/snyk.test.ts
@@ -29,11 +29,11 @@ describe('Snyk Token Validation', () => {
       .persist()
       .get(`/rest/self?version=2024-05-31`)
       .reply(() => {
-        return [200, 'OK']
+        return [200, {data: {id: 'some-user-id'}}]
       })
     try {
-      await validateSnykToken('523022f6-33af-4791-a25a-8ade918c3c78')
-      expect(true).to.be.true
+      const userId = await validateSnykToken('523022f6-33af-4791-a25a-8ade918c3c78')
+      expect(userId).to.eq('some-user-id')
     } catch (error) {
       expect(error).to.be.undefined
     }

--- a/test/api/tenants.test.ts
+++ b/test/api/tenants.test.ts
@@ -1,8 +1,9 @@
-import {getAccessibleTenants, getTenantRole} from '../../src/api/tenants'
+import {getAccessibleTenants, isTenantAdmin} from '../../src/api/tenants'
 import {expect} from 'chai'
 import nock from 'nock'
 
 describe('Tenants Api calls', () => {
+  const userId = '00000000-0000-0000-0000-000000000000'
   const tenantId = '00000000-0000-0000-0000-000000000000'
   const tenants = {
     data: [
@@ -80,7 +81,7 @@ describe('Tenants Api calls', () => {
       .reply(() => {
         return [200, tenants]
       })
-      .get(`/rest/tenants/${tenantId}/memberships?role_name=admin&version=2024-10-14~experimental`)
+      .get(`/rest/tenants/${tenantId}/memberships?role_name=admin&user_id=${userId}&version=2024-10-14~experimental`)
       .reply(() => {
         return [200, tenantRoles]
       })
@@ -90,8 +91,8 @@ describe('Tenants Api calls', () => {
     expect(accessibleTenants).to.deep.equal(tenants)
   })
 
-  it('getTenantRole', async () => {
-    const tenantRoles = await getTenantRole(tenantId)
+  it('isTenantAdmin', async () => {
+    const tenantRoles = await isTenantAdmin(tenantId, userId)
     expect(tenantRoles).to.deep.equal(tenantRoles)
   })
 })

--- a/test/test-utils/nock-utils.ts
+++ b/test/test-utils/nock-utils.ts
@@ -4,6 +4,7 @@ import {ConnectionResponse, GetOrgsForBulkMigrationResponse} from '../../src/api
 export const upArrow = '\u001b[A'
 export const downArrow = '\u001b[B'
 export const tab = '\u0009'
+export const userId = '00000000-0000-0000-0000-000000000000'
 export const appId = 'cb43d761-bd17-4b44-9b6c-e5b8ad077d33'
 export const snykToken = 'cb43d761-bd17-4b44-9b6c-e5b8ad077d33'
 export const orgId = '3a7c1ab9-8914-4f39-a8c0-5752af653a88'
@@ -82,7 +83,7 @@ export const tenants = {
   ],
 }
 
-const tenantRoles = {
+const tenantMemberships = {
   data: [
     {
       type: 'tenant_membership',
@@ -129,7 +130,7 @@ const tenantRoles = {
   jsonapi: {},
 }
 
-export const forbiddenTenantMembersResponse = {
+const forbiddenTenantMembersResponse = {
   jsonapi: {
     version: '1.0',
   },
@@ -283,6 +284,20 @@ export const createCredentialsResponse = {
   ],
 }
 
+const selfResponse = {
+    data: {
+      id: userId,
+      type: 'user',
+      attributes: {
+        avatar_url: '',
+        default_org_context: '',
+        email: '',
+        name: '',
+        username: '',
+      },
+    },
+  }
+
 const urlPrefixTenantIdAndInstallId = `/rest/tenants/${tenantId}/brokers/installs/${installId}`
 const urlPrefixTenantIdAndInstallId2 = `/rest/tenants/${tenantId}/brokers/installs/${installId2}`
 const urlPrefixTenantIdAndInstallId3 = `/rest/tenants/${tenantId}/brokers/installs/${installId3}`
@@ -312,7 +327,7 @@ export const beforeStep = () => {
     .persist()
     .get(`/rest/self?version=2024-05-31`)
     .reply(() => {
-      return [200, 'OK']
+      return [200, selfResponse]
     })
     .get(`/rest/orgs/${orgId}/apps/installs?version=2024-05-31`)
     .reply(() => {
@@ -342,13 +357,13 @@ export const beforeStep = () => {
     .reply(() => {
       return [200, tenants]
     })
-    .get(`/rest/tenants/${tenantId}/memberships?role_name=admin&version=2024-10-14~experimental`)
+    .get(`/rest/tenants/${tenantId}/memberships?role_name=admin&user_id=${userId}&version=2024-10-14~experimental`)
     .reply(() => {
-      return [200, tenantRoles]
+      return [200, tenantMemberships]
     })
-    .get(`/rest/tenants/${nonAdminTenantId}/memberships?role_name=admin&version=2024-10-14~experimental`)
+    .get(`/rest/tenants/${nonAdminTenantId}/memberships?role_name=admin&user_id=${userId}&version=2024-10-14~experimental`)
     .reply(() => {
-      return [403, forbiddenTenantMembersResponse]
+      return [200, forbiddenTenantMembersResponse]
     })
     .get(`${urlPrefixTenantIdAndInstallId}/deployments?version=2024-10-15`)
     .reply((uri, body) => {

--- a/test/workflows/deployments/get-failed-due-to-tenant-role.test.ts
+++ b/test/workflows/deployments/get-failed-due-to-tenant-role.test.ts
@@ -3,7 +3,7 @@ import {expect} from 'chai'
 import {stdin as fstdin} from 'mock-stdin'
 
 import Deployments from '../../../src/commands/workflows/deployments/get'
-import {beforeStep, orgId, snykToken} from '../../test-utils/nock-utils'
+import {beforeStep, orgId, snykToken, nonAdminTenantId} from '../../test-utils/nock-utils'
 import {sendScenario} from '../../test-utils/stdin-utils'
 
 describe('deployment workflows', () => {
@@ -13,7 +13,7 @@ describe('deployment workflows', () => {
     delete process.env.TENANT_ID
   })
   it('runs workflow deployment list', async () => {
-    process.env.TENANT_ID = '00000000-0000-0000-0000-000000000001'
+    process.env.TENANT_ID = nonAdminTenantId
     const stdin = fstdin()
     // @ts-ignore
     const cfg: Config = {}


### PR DESCRIPTION
Returns a failure message if the user running the command does not authorize as a Tenant admin. Also tightens up the Tenant membership request so we are only returning the membership of the user running the command and not all Tenant memberships.

This update will more gracefully handle the three potential states a user could be in:
* Is a Tenant Admin
* Is not a Tenant Admin, but does have permission to list memberships within a Tenant
* Does not have permission to list memberships within a Tenant