### PR TITLE
chore: update example for url params

### DIFF
--- a/src/command-helpers/connections/parameters-capture.ts
+++ b/src/command-helpers/connections/parameters-capture.ts
@@ -125,7 +125,7 @@ export const captureConnectionParams = async (
       console.log(
         ux.colorize(
           'yellow',
-          `\nHint! your credential reference URL value should have the following format: ${value.exampleFormat}.\n`,
+          `\nHint! Your credential reference URL value should have the following format: ${value.exampleFormat}.\n`,
         ),
       )
     }

--- a/src/command-helpers/connections/parameters-capture.ts
+++ b/src/command-helpers/connections/parameters-capture.ts
@@ -5,6 +5,7 @@ import {CredentialsAttributes, CredentialsListResponse} from '../../api/types.js
 import {isNotProhibitedValue, isValidHostnameWithPort, isValidUrl, isValidUUID} from '../../utils/validation.js'
 import {validatedInput, ValidationType} from '../../utils/input-validation.js'
 import {getConfig} from '../../config/config.js'
+import {ux} from '@oclif/core'
 
 export const captureConnectionParams = async (
   tenantID: string,
@@ -74,6 +75,7 @@ export const captureConnectionParams = async (
         }
         requiredParameters[key].input = selectedCredId.id
       }
+
     } else {
       let isInputValidated = false
       let message = `${key}: ${value.description}. `
@@ -119,6 +121,10 @@ export const captureConnectionParams = async (
           isInputValidated = true
         }
       }
+
+    }
+    if (value.exampleFormat) {
+      console.log(ux.colorize('yellow', `\nHint! your credential reference URL value should have the following format: ${value.exampleFormat}.\n`))
     }
   }
   const connectionParams: Record<string, string> = {}

--- a/src/command-helpers/connections/parameters-capture.ts
+++ b/src/command-helpers/connections/parameters-capture.ts
@@ -75,7 +75,6 @@ export const captureConnectionParams = async (
         }
         requiredParameters[key].input = selectedCredId.id
       }
-
     } else {
       let isInputValidated = false
       let message = `${key}: ${value.description}. `
@@ -121,10 +120,14 @@ export const captureConnectionParams = async (
           isInputValidated = true
         }
       }
-
     }
     if (value.exampleFormat) {
-      console.log(ux.colorize('yellow', `\nHint! your credential reference URL value should have the following format: ${value.exampleFormat}.\n`))
+      console.log(
+        ux.colorize(
+          'yellow',
+          `\nHint! your credential reference URL value should have the following format: ${value.exampleFormat}.\n`,
+        ),
+      )
     }
   }
   const connectionParams: Record<string, string> = {}

--- a/src/command-helpers/connections/type-params-mapping.ts
+++ b/src/command-helpers/connections/type-params-mapping.ts
@@ -42,6 +42,7 @@ export interface TypeParams {
     dataType?: 'hostname' | 'url'
     skippable?: boolean
     prohibitedValues: string[]
+    exampleFormat?: string
   }
 }
 
@@ -82,6 +83,7 @@ export const flagConnectionMapping: TypeMapping = {
       description: 'Artifactory URL (Credentials Reference UUID as it may contain sensitive values)',
       sensitive: true,
       prohibitedValues: [],
+      exampleFormat: '<username>:<password>@<yourdomain.artifactory.com>/artifactory'
     },
   },
   jira: {
@@ -105,6 +107,7 @@ export const flagConnectionMapping: TypeMapping = {
       description: 'Nexus URL (Credentials Reference UUID as it may contain sensitive values)',
       sensitive: true,
       prohibitedValues: [],
+      exampleFormat: 'https://<username>:<password>@<your.nexus.hostname>'
     },
   },
   'azure-repos': {

--- a/src/command-helpers/connections/type-params-mapping.ts
+++ b/src/command-helpers/connections/type-params-mapping.ts
@@ -83,7 +83,7 @@ export const flagConnectionMapping: TypeMapping = {
       description: 'Artifactory URL (Credentials Reference UUID as it may contain sensitive values)',
       sensitive: true,
       prohibitedValues: [],
-      exampleFormat: '<username>:<password>@<yourdomain.artifactory.com>/artifactory'
+      exampleFormat: '<username>:<password>@<yourdomain.artifactory.com>/artifactory',
     },
   },
   jira: {
@@ -107,7 +107,7 @@ export const flagConnectionMapping: TypeMapping = {
       description: 'Nexus URL (Credentials Reference UUID as it may contain sensitive values)',
       sensitive: true,
       prohibitedValues: [],
-      exampleFormat: 'https://<username>:<password>@<your.nexus.hostname>'
+      exampleFormat: 'https://<username>:<password>@<your.nexus.hostname>',
     },
   },
   'azure-repos': {

--- a/src/commands/workflows/connections/create.ts
+++ b/src/commands/workflows/connections/create.ts
@@ -28,7 +28,7 @@ export default class Workflows extends BaseCommand<typeof Workflows> {
       this.log(
         ux.colorize(
           'yellow',
-          `Helpful tip ! You can use a credentials reference for any field by simply entering the creds ref UUID. Use workflows credentials create|get to create|list available credentials reference(s).\n`,
+          `Helpful tip! You can use a credentials reference for any field by simply entering the creds ref UUID. Use workflows credentials create|get to create|list available credentials reference(s).\n`,
         ),
       )
 


### PR DESCRIPTION
This PR adds a new optional field in the params called `exampleFormat` which can be used to provide formatting hints for the user. This is useful for fields like the `artifactory_url` which requires a username and password. 