### PR TITLE
fix: error on bad deployment ID [ACC-3092]

### DIFF
--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -26,7 +26,7 @@ export const getConnectionsForDeployment = async (tenantId: string, installId: s
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     if (response.statusCode && response.statusCode === 404) {
-      return {data: [], errors: [{details: '404'}]}
+      return {data: [], jsonapi: {version: ''}, links: {}}
     }
     return JSON.parse(response.body) as ConnectionsResponse
   } catch (error: any) {

--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -25,6 +25,9 @@ export const getConnectionsForDeployment = async (tenantId: string, installId: s
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+    if (response.statusCode && response.statusCode === 404) {
+      return {data: [], errors: [{details: '404'}]}
+    }
     return JSON.parse(response.body) as ConnectionsResponse
   } catch (error: any) {
     throw new Error(error)

--- a/src/api/credentials.ts
+++ b/src/api/credentials.ts
@@ -27,7 +27,7 @@ export const getCredentialsForDeployment = async (tenantId: string, installId: s
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     if (response.statusCode && response.statusCode === 404) {
-      return {data: [], errors: [{details: '404'}]}
+      return {data: [], jsonapi: {version: ''}, links: {}}
     }
     return JSON.parse(response.body) as CredentialsListResponse
   } catch (error: any) {

--- a/src/api/credentials.ts
+++ b/src/api/credentials.ts
@@ -26,6 +26,9 @@ export const getCredentialsForDeployment = async (tenantId: string, installId: s
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+    if (response.statusCode && response.statusCode === 404) {
+      return {data: [], errors: [{details: '404'}]}
+    }
     return JSON.parse(response.body) as CredentialsListResponse
   } catch (error: any) {
     throw new Error(error)

--- a/test/api/connections.test.ts
+++ b/test/api/connections.test.ts
@@ -13,8 +13,6 @@ import {
   GetOrgsForBulkMigrationResponse,
   OrgResource,
 } from '../../src/api/types'
-import {getConfig} from '../../src/config/config'
-
 describe('Connections Api calls', () => {
   const getConnectionsResponse: ConnectionsResponse = {
     data: [
@@ -61,7 +59,7 @@ describe('Connections Api calls', () => {
   }
   before(() => {
     process.env.SNYK_TOKEN = 'dummy'
-    nock(getConfig().API_HOSTNAME)
+    nock('https://api.snyk.io')
       .persist()
       .post(
         '/rest/tenants/00000000-0000-0000-0000-000000000000/brokers/installs/00000000-0000-0000-0000-000000000000/deployments/00000000-0000-0000-0000-000000000000/connections?version=2024-10-15',

--- a/test/api/connections.test.ts
+++ b/test/api/connections.test.ts
@@ -3,12 +3,32 @@ import {
   updateConnectionForDeployment,
   deleteConnectionForDeployment,
   getBulkMigrationOrgs,
+  getConnectionsForDeployment,
 } from '../../src/api/connections'
 import {expect} from 'chai'
 import nock from 'nock'
-import {ConnectionResponse, GetOrgsForBulkMigrationResponse, OrgResource} from '../../src/api/types'
+import {
+  ConnectionResponse,
+  ConnectionsResponse,
+  GetOrgsForBulkMigrationResponse,
+  OrgResource,
+} from '../../src/api/types'
+import {getConfig} from '../../src/config/config'
 
 describe('Connections Api calls', () => {
+  const getConnectionsResponse: ConnectionsResponse = {
+    data: [
+      {
+        id: '00000000-0000-0000-0000-000000000000',
+        type: 'broker_connection',
+        attributes: {},
+      },
+    ],
+    jsonapi: {
+      version: 'dummy',
+    },
+    links: {},
+  }
   const createResponse: ConnectionResponse = {
     data: {
       id: '00000000-0000-0000-0000-000000000000',
@@ -41,7 +61,7 @@ describe('Connections Api calls', () => {
   }
   before(() => {
     process.env.SNYK_TOKEN = 'dummy'
-    nock('https://api.snyk.io')
+    nock(getConfig().API_HOSTNAME)
       .persist()
       .post(
         '/rest/tenants/00000000-0000-0000-0000-000000000000/brokers/installs/00000000-0000-0000-0000-000000000000/deployments/00000000-0000-0000-0000-000000000000/connections?version=2024-10-15',
@@ -75,6 +95,14 @@ describe('Connections Api calls', () => {
         '/rest/tenants/00000000-0000-0000-0000-000000000000/brokers/installs/00000000-0000-0000-0000-000000000000/deployments/00000000-0000-0000-0000-000000000000/connections/00000000-0000-0000-0000-000000000000/bulk_migration?version=2024-10-15',
       )
       .reply(200, bulkMigrationMockResponse)
+      .get(
+        '/rest/tenants/00000000-0000-0000-0000-000000000000/brokers/installs/00000000-0000-0000-0000-000000000000/deployments/00000000-0000-0000-0000-000000000000/connections?version=2024-10-15',
+      )
+      .reply(200, getConnectionsResponse)
+      .get(
+        '/rest/tenants/00000000-0000-0000-0000-000000000000/brokers/installs/00000000-0000-0000-0000-000000000000/deployments/invalid-deployment-id/connections?version=2024-10-15',
+      )
+      .reply(404)
   })
   it('createConnectionForDeployment', async () => {
     const createConnectionResponse = await createConnectionForDeployment(
@@ -139,5 +167,23 @@ describe('Connections Api calls', () => {
       '00000000-0000-0000-0000-000000000000', // connectionId
     )
     expect(response).to.deep.equal(bulkMigrationMockResponse)
+  })
+
+  it('getConnectionsForDeployment', async () => {
+    const response = await getConnectionsForDeployment(
+      '00000000-0000-0000-0000-000000000000',
+      '00000000-0000-0000-0000-000000000000',
+      '00000000-0000-0000-0000-000000000000',
+    )
+    expect(response).to.deep.equal(getConnectionsResponse)
+  })
+
+  it('getConnectionsForDeployment handles 404', async () => {
+    const response = await getConnectionsForDeployment(
+      '00000000-0000-0000-0000-000000000000',
+      '00000000-0000-0000-0000-000000000000',
+      'invalid-deployment-id',
+    )
+    expect(response).to.deep.equal({data: [], jsonapi: {version: ''}, links: {}})
   })
 })

--- a/test/commands/credentials/list.test.ts
+++ b/test/commands/credentials/list.test.ts
@@ -1,0 +1,59 @@
+import {captureOutput} from '@oclif/test'
+import {expect} from 'chai'
+import nock from 'nock'
+import Credentials from '../../../src/commands/credentials/list'
+
+describe('credentials list command', () => {
+  const tenantId = '00000000-0000-0000-0000-000000000000'
+  const installId = '00000000-0000-0000-0000-000000000000'
+  const deploymentId = 'invalid-deployment-id'
+
+  before(() => {
+    process.env.SNYK_TOKEN = 'dummy'
+    process.env.TENANT_ID = tenantId
+    process.env.INSTALL_ID = installId
+  })
+
+  after(() => {
+    delete process.env.SNYK_TOKEN
+    delete process.env.TENANT_ID
+    delete process.env.INSTALL_ID
+    nock.cleanAll()
+  })
+
+  it('handles invalid deployment ID gracefully (404 response with no data)', async () => {
+    nock('https://api.snyk.io')
+      .get(`/rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/credentials`)
+      .query(true)
+      .reply(404, {
+        errors: [{
+            status: "404",
+            title: "Not Found",
+            detail: "Deployment not found"
+        }]
+      })
+
+    const mockConfig: any = {
+        runHook: () => Promise.resolve({successes: [], failures: []}),
+        runCommand: () => Promise.resolve(),
+        scopedEnvVarKey: () => '',
+        bin: 'snyk-broker-config',
+        topicSeparator: ' ',
+        pjson: {
+            oclif: {
+                topicSeparator: ' ',
+            }
+        },
+        plugins: new Map(),
+    }
+
+    // Since class is loaded before env vars are set, args definition expects tenantId and installId
+    const cmd = new Credentials([tenantId, installId, deploymentId], mockConfig)
+
+    const {error, stdout} = await captureOutput(async () => cmd.run(), {print: false})
+    if (error) {
+        throw new Error(`Command failed unexpectedly: ${error.message}`)
+    }
+    expect(stdout).to.contain('Total = 0')
+  })
+})


### PR DESCRIPTION
This fixes an error where the credentials list cannot be parsed because the API returned a 404. 

```
❯ ./bin/dev.js credentials list $TENANT_ID $INSTALL_ID $BAD_DEPLOYMENT_ID

Using https://api.dev.snyk.io.

Universal Broker Deployments - List operation
Getting Universal Broker Credentials for Deployment $BAD_DEPLOYMENT_ID, Tenant $TENANT_ID, Install $INSTALL_ID
Total = 0

❯ ./bin/dev.js connections list $TENANT_ID $INSTALL_ID $BAD_DEPLOYMENT_ID

Using https://api.dev.snyk.io.

Universal Broker Connections - List operation
Getting Universal Broker Connections for Deployment $BAD_DEPLOYMENT_ID, Tenant $TENANT_ID, Install $INSTALL_ID
Total = 0
```