### PR TITLE
fix: improve SNYK_BROKER_APP_ID error messages

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -66,8 +66,16 @@ export const getExistingAppInstalledOnOrgId = async (orgId: string): Promise<App
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     const installs = JSON.parse(response.body) as AppInstallsResponse
 
-    return installs.data.find((x) => x.relationships.app.data.id === appId)
+    const existingInstall = installs.data.find((x) => x.relationships.app.data.id === appId)
+    if (!existingInstall && installs.data.length > 0) {
+      throw new Error(`No Broker App installation found with the configured SNYK_BROKER_APP_ID (${appId}).`)
+    }
+
+    return existingInstall
   } catch (error: any) {
+    if (error.message.includes('No Broker App installation found')) {
+      throw error
+    }
     throw new Error(error)
   }
 }

--- a/test/api/apps.test.ts
+++ b/test/api/apps.test.ts
@@ -50,8 +50,55 @@ describe('Broker App Api calls', () => {
   it('get no installed broker app if app id is not found ', async () => {
     process.env.SNYK_BROKER_APP_ID = 'dummy'
     const orgId = '00000000-0000-0000-0000-00000000000'
-    const installedApp = await getExistingAppInstalledOnOrgId(orgId)
-    expect(installedApp).to.be.undefined
+
+    try {
+      await getExistingAppInstalledOnOrgId(orgId)
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.include(
+        'No Broker App installation found with the configured SNYK_BROKER_APP_ID (dummy)',
+      )
+    }
+
+    delete process.env.SNYK_BROKER_APP_ID
+  })
+
+  it('should throw helpful error when wrong SNYK_BROKER_APP_ID is configured', async () => {
+    const responseWithDifferentApps = {
+      data: [
+        {
+          id: `456`,
+          type: 'app_install',
+          attributes: {
+            client_id: '11111111-1234-0000-0000-000000000000',
+            installed_at: '2024-07-17T18:51:02Z',
+          },
+          relationships: {
+            app: {
+              data: {
+                id: 'different-app-id-1234-5678-9abc-def012345678',
+                type: 'app',
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    nock('https://api.snyk.io')
+      .get(`/rest/orgs/wrong-app-id-test-org/apps/installs?version=2024-05-31`)
+      .reply(200, responseWithDifferentApps)
+
+    process.env.SNYK_BROKER_APP_ID = 'wrong-app-id-9999-8888-7777-666555444333'
+    const orgId = 'wrong-app-id-test-org'
+
+    try {
+      await getExistingAppInstalledOnOrgId(orgId)
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.include('No Broker App installation found with the configured SNYK_BROKER_APP_ID')
+      expect(error.message).to.include('wrong-app-id-9999-8888-7777-666555444333')
+    }
     delete process.env.SNYK_BROKER_APP_ID
   })
 })


### PR DESCRIPTION
### Problem
- When using snyk-broker-config CLI tool against dev environment we encounter a cryptic error `"Cannot read properties of undefined (reading 'id')"` when using the wrong `SNYK_BROKER_APP_ID` environment variable. This happened because: `getExistingAppInstalledOnOrgId()` would return `undefined` when the configured app ID wasn't found.
- Subsequent code tried to access the `.id` property on the `undefined` result.
- The error message provided no context about the actual issue.

### Solution
- Improved error handling to provide clear error messages.
