### PR TITLE
feat: handle context deletion errors [ACC-3133]

### DIFF
--- a/src/api/contexts.ts
+++ b/src/api/contexts.ts
@@ -73,12 +73,13 @@ export const deleteContextById = async (tenantId: string, installId: string, con
     method: 'DELETE',
   }
 
-  const response = await makeRequest(req)
-  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-  if (!response.statusCode || response.statusCode > 299) {
-    throw new Error(`Deleting context ${contextId}. Response code ${response.statusCode ?? 'none'}.`)
+  try {
+    const response = await makeRequest(req)
+    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+    return response.statusCode
+  } catch (error: any) {
+    throw new Error(error)
   }
-  return response.statusCode
 }
 
 export const applyContext = async (tenantId: string, installId: string, contextId: string, orgId: string) => {


### PR DESCRIPTION
This makes the `deleteContextById` method handle the error returned by the Hybrid Platform Service if attempting to delete a context that will leave orphaned context references.

```? Are you sure you want to delete Context 6040244a-f54f-45de-898e-174c3e7a1a63 ? yes
Deleting Context 6040244a-f54f-45de-898e-174c3e7a1a63
Error: 400: Bad Request.

- Url: (DELETE)https://api.dev.snyk.io/rest/tenants/d1306269-534e-4500-9ea3-a46430f052d5/brokers/installs/c7b590c8-1f35-4b4d-9d4f-1b3ff0c0de47/contexts/6040244a-f54f-45de-898e-174c3e7a1a63?version=2024-02-08~experimental.

- Context cannot be deleted as it is associated with one or more integrations```