### PR TITLE
fix(circleci): update resource_class for macos and win jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
   build-macos:
     macos:
       xcode: 16.4.0
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
     steps:
       - checkout
       - attach_workspace:
@@ -79,7 +79,7 @@ jobs:
   build-win:
     macos:
       xcode: 16.4.0
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This PR fixes failing jobs `build-win` and `build-macos`. CircleCI deprecated `macos.m1.medium.gen1` resource. Now only available resources are:
- `m4pro.medium`
- `m4pro.large`

`m4pro.medium` is enough to build the binary.

https://circleci.com/docs/guides/execution-managed/using-macos/#supported-xcode-versions



Example of failed job: https://app.circleci.com/pipelines/github/snyk/snyk-broker-config/300/workflows/9cb05eba-d59d-4c1e-88b1-f6e65930bc64/jobs/1352
