### PR TITLE
fix: fixes error when org has previous apps installed

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -67,15 +67,9 @@ export const getExistingAppInstalledOnOrgId = async (orgId: string): Promise<App
     const installs = JSON.parse(response.body) as AppInstallsResponse
 
     const existingInstall = installs.data.find((x) => x.relationships.app.data.id === appId)
-    if (!existingInstall && installs.data.length > 0) {
-      throw new Error(`No Broker App installation found with the configured SNYK_BROKER_APP_ID (${appId}).`)
-    }
 
     return existingInstall
   } catch (error: any) {
-    if (error.message.includes('No Broker App installation found')) {
-      throw error
-    }
     throw new Error(error)
   }
 }

--- a/test/api/apps.test.ts
+++ b/test/api/apps.test.ts
@@ -47,23 +47,18 @@ describe('Broker App Api calls', () => {
     expect(installedApp).to.deep.equal(response.data[0])
   })
 
-  it('get no installed broker app if app id is not found ', async () => {
-    process.env.SNYK_BROKER_APP_ID = 'dummy'
-    const orgId = '00000000-0000-0000-0000-00000000000'
+  it('returns undefined when no apps are installed', async () => {
+    const orgId = 'no-apps-installed-org-id'
 
-    try {
-      await getExistingAppInstalledOnOrgId(orgId)
-      expect.fail('Should have thrown an error')
-    } catch (error: any) {
-      expect(error.message).to.include(
-        'No Broker App installation found with the configured SNYK_BROKER_APP_ID (dummy)',
-      )
-    }
+    nock('https://api.snyk.io')
+      .get(`/rest/orgs/${orgId}/apps/installs?version=2024-05-31`)
+      .reply(200, {data: []})
 
-    delete process.env.SNYK_BROKER_APP_ID
+    const installedApp = await getExistingAppInstalledOnOrgId(orgId)
+    expect(installedApp).to.be.undefined
   })
 
-  it('should throw helpful error when wrong SNYK_BROKER_APP_ID is configured', async () => {
+  it('returns undefined when SNYK_BROKER_APP_ID does not match any installed app', async () => {
     const responseWithDifferentApps = {
       data: [
         {
@@ -85,20 +80,13 @@ describe('Broker App Api calls', () => {
       ],
     }
 
+    const orgId = 'apps-installed-org-id'
     nock('https://api.snyk.io')
-      .get(`/rest/orgs/wrong-app-id-test-org/apps/installs?version=2024-05-31`)
+      .get(`/rest/orgs/${orgId}/apps/installs?version=2024-05-31`)
       .reply(200, responseWithDifferentApps)
 
-    process.env.SNYK_BROKER_APP_ID = 'wrong-app-id-9999-8888-7777-666555444333'
-    const orgId = 'wrong-app-id-test-org'
 
-    try {
-      await getExistingAppInstalledOnOrgId(orgId)
-      expect.fail('Should have thrown an error')
-    } catch (error: any) {
-      expect(error.message).to.include('No Broker App installation found with the configured SNYK_BROKER_APP_ID')
-      expect(error.message).to.include('wrong-app-id-9999-8888-7777-666555444333')
-    }
-    delete process.env.SNYK_BROKER_APP_ID
+    const installedApp = await getExistingAppInstalledOnOrgId(orgId)
+    expect(installedApp).to.be.undefined
   })
 })


### PR DESCRIPTION
As part of 1.24 we introduced a change that attempted to catch a common misconfig scenario whereby the wrong broker app ID was used when using the config cli. This change would throw a descriptive error if the target org had snyk apps installed that did _not_ match the broker app ID.

This is problematic given there are many snyk apps. This caused an issue whereby if an org had previously installed apps unrelated to the broker, the cli would crash at the point it tries to determine if the broker app is already installed.

This fix, restores the < 1.24 behaviour whereby we return undefined in the case the broker app is not installed.

Ticket to look at reimplementing a more robust solution to cross-environment broker_app_id configuration: https://snyksec.atlassian.net/browse/ACC-3271