### PR TITLE
refactor: add request and interaction ids to telemetry

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -24,7 +24,7 @@ export const installAppIdOnOrgId = async (orgId: string): Promise<AppInstallResp
     },
   }
 
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/orgs/${orgId}/apps/installs`
   const config = getConfig()
 
@@ -52,7 +52,7 @@ export const installAppIdOnOrgId = async (orgId: string): Promise<AppInstallResp
 export const getExistingAppInstalledOnOrgId = async (orgId: string): Promise<AppInstallResponseData | undefined> => {
   const appId = process.env.SNYK_BROKER_APP_ID ?? 'cb43d761-bd17-4b44-9b6c-e5b8ad077d33'
 
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/orgs/${orgId}/apps/installs`
   const config = getConfig()
 

--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -13,7 +13,7 @@ import {
 const logger = createLogger('snyk-broker-config')
 
 export const getConnectionsForDeployment = async (tenantId: string, installId: string, deploymentId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections`
   const config = getConfig()
 
@@ -40,7 +40,7 @@ export const applyBulkMigration = async (
   deploymentId: string,
   connectionId: string,
 ): Promise<applyBulkMigrationResponse> => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections/${connectionId}/bulk_migration`
   const config = getConfig()
 
@@ -71,7 +71,7 @@ export const getBulkMigrationOrgs = async (
   deploymentId: string,
   connectionId: string,
 ): Promise<GetOrgsForBulkMigrationResponse> => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections/${connectionId}/bulk_migration`
   const config = getConfig()
 
@@ -97,7 +97,7 @@ export const createConnectionForDeployment = async (
   connectionType: string,
   requiredConfigurationAttributes: Record<string, string>,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections`
   const config = getConfig()
 
@@ -141,7 +141,7 @@ export const updateConnectionForDeployment = async (
   connectionType: string,
   requiredConfigurationAttributes: Record<string, string>,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections/${connectionId}`
   const config = getConfig()
 
@@ -181,7 +181,7 @@ export const deleteConnectionForDeployment = async (
   deploymentId: string,
   connectionId: string,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const config = getConfig()
 
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections/${connectionId}`

--- a/src/api/contexts.ts
+++ b/src/api/contexts.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -8,7 +8,7 @@ import {ApplyContextResponse, ContextResponse, ContextsResponse} from './types.j
 const logger = createLogger('snyk-broker-config')
 
 export const getContextsForForDeployment = async (tenantId: string, installId: string, deploymentId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/contexts`
   const config = getConfig()
 
@@ -33,7 +33,7 @@ export const createContextForConnection = async (
   connectionId: string,
   parameters: Record<string, string>,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/contexts`
   const config = getConfig()
 
@@ -63,7 +63,7 @@ export const createContextForConnection = async (
 }
 
 export const deleteContextById = async (tenantId: string, installId: string, contextId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const config = getConfig()
 
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/contexts/${contextId}`
@@ -83,7 +83,7 @@ export const deleteContextById = async (tenantId: string, installId: string, con
 }
 
 export const applyContext = async (tenantId: string, installId: string, contextId: string, orgId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/contexts/${contextId}/integration`
   const config = getConfig()
 
@@ -119,7 +119,7 @@ export const withdrawContext = async (
   contextId: string,
   integrationId: string,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/contexts/${contextId}/integrations/${integrationId}`
   const config = getConfig()
 

--- a/src/api/credentials.ts
+++ b/src/api/credentials.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -14,7 +14,7 @@ import {
 const logger = createLogger('snyk-broker-config')
 
 export const getCredentialsForDeployment = async (tenantId: string, installId: string, deploymentId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/credentials`
   const config = getConfig()
 
@@ -41,7 +41,7 @@ export const getCredentialForDeployment = async (
   deploymentId: string,
   credentialId: string,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/credentials/${credentialId}`
   const config = getConfig()
 
@@ -65,7 +65,7 @@ export const createCredentials = async (
   deploymentId: string,
   attributesArray: CredentialsAttributes[],
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/credentials`
   const config = getConfig()
   const body = {
@@ -95,7 +95,7 @@ export const deleteCredentials = async (
   deploymentId: string,
   credentialsId: string,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const config = getConfig()
 
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/credentials/${credentialsId}`
@@ -120,7 +120,7 @@ export const updateCredentials = async (
   credentialsId: string,
   attributes: CredentialsAttributes,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/credentials/${credentialsId}`
   const config = getConfig()
   const body = {

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -41,7 +41,7 @@ export interface DeploymentsResponse {
 }
 
 export const getDeployments = async (tenantId: string, installId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments`
   const config = getConfig()
 
@@ -66,7 +66,7 @@ export const createDeployment = async (
   installId: string,
   deploymentAttributes: DeploymentAttributesMetadata,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments`
   const config = getConfig()
   const body = {
@@ -93,7 +93,7 @@ export const createDeployment = async (
 }
 
 export const deleteDeployment = async (tenantId: string, installId: string, deploymentId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}`
   const config = getConfig()
 
@@ -114,7 +114,7 @@ export const updateDeployment = async (
   deploymentMetadata: DeploymentAttributesMetadata,
   deploymentAttributes?: Omit<UpdateDeploymentAttributes, 'metadata'>,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}`
   const config = getConfig()
   const body = {

--- a/src/api/integrations.ts
+++ b/src/api/integrations.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -15,7 +15,7 @@ interface IntegrationBody {
   }
 }
 export const getIntegrationsForConnection = async (tenantId: string, connectionId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/connections/${connectionId}/integrations`
   const config = getConfig()
 
@@ -39,7 +39,7 @@ export const deleteIntegrationsForConnection = async (
   orgId: string,
   integrationId: string,
 ) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/connections/${connectionId}/orgs/${orgId}/integrations/${integrationId}`
   const config = getConfig()
 
@@ -64,7 +64,7 @@ export const createIntegrationForConnection = async (
   orgId: string,
   integrationId?: string,
 ): Promise<IntegrationResponse> => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/brokers/connections/${connectionId}/orgs/${orgId}/integration`
   const config = getConfig()
 
@@ -97,6 +97,7 @@ export const disconnectIntegrationForOrgIdAndIntegrationId = async (
   type: string,
 ): Promise<void> => {
   const headers = {
+    ...getCommonHeaders(),
     'user-agent': 'Hybrid Platform Service',
     'Content-Type': 'application/json; charset=utf-8',
     ...getAuthHeader(),

--- a/src/api/snyk.ts
+++ b/src/api/snyk.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -26,7 +26,7 @@ export const validateSnykToken = async (snykToken: string): Promise<string> => {
     throw new Error('Invalid Format.')
   }
   process.env.SNYK_TOKEN = snykToken
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/self`
   const config = getConfig()
 

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -1,4 +1,4 @@
-import {commonHeaders} from '../common/rest-helpers.js'
+import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
@@ -30,7 +30,7 @@ interface TenantsListingResponse {
 const logger = createLogger('snyk-broker-config')
 
 export const getAccessibleTenants = async () => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants`
   const config = getConfig()
 
@@ -96,7 +96,7 @@ interface TenantsMembershipResponse {
 }
 
 export const isTenantAdmin = async (tenantId: string, userId: string) => {
-  const headers = {...commonHeaders, ...getAuthHeader()}
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
   const apiPath = `rest/tenants/${tenantId}/memberships`
   const config = getConfig()
 

--- a/src/common/rest-helpers.ts
+++ b/src/common/rest-helpers.ts
@@ -1,3 +1,8 @@
-export const commonHeaders = {
+import {randomUUID} from 'node:crypto'
+
+const interactionId = randomUUID()
+
+export const getCommonHeaders = () => ({
   'Content-Type': 'application/vnd.api+json',
-}
+  'SNYK-INTERACTION-ID': interactionId,
+})

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -1,3 +1,4 @@
+import {randomUUID} from 'node:crypto'
 import http from 'node:http'
 import https from 'node:https'
 import {getProxyForUrl} from 'proxy-from-env'
@@ -30,6 +31,11 @@ if (process.env.NP_PROXY || process.env.no_proxy) {
 
 export const makeRequest = async (req: HttpRequest, retries = MAX_RETRY): Promise<HttpResponse> => {
   const localRequest = req
+  if (!(localRequest.headers as Record<string, string>)['SNYK-REQUEST-ID']) {
+    ;(localRequest.headers as Record<string, string>)['SNYK-REQUEST-ID'] = randomUUID()
+  }
+  const requestId = (localRequest.headers as Record<string, string>)['SNYK-REQUEST-ID']
+  const interactionId = (localRequest.headers as Record<string, string>)['SNYK-INTERACTION-ID']
   const proxyUri = getProxyForUrl(localRequest.url)
   if (proxyUri) {
     bootstrap({
@@ -57,7 +63,7 @@ export const makeRequest = async (req: HttpRequest, retries = MAX_RETRY): Promis
           if (response.statusCode && response.statusCode > 299 && response.statusCode !== 404) {
             const errors = (JSON.parse(data).errors as Array<any>) ?? ''
             reject(
-              `${response.statusCode}: ${response.statusMessage}.\n\n- Url: (${req.method})${req.url}.\n\n- ${errors.map((error) => error.detail).join(';')}`,
+              `${response.statusCode}: ${response.statusMessage}.\n\n- Url: (${req.method})${req.url}.\n- requestId: ${requestId}\n- interactionId: ${interactionId}\n\n- ${errors.map((error) => error.detail).join(';')}`,
             )
           }
           resolve({
@@ -70,18 +76,18 @@ export const makeRequest = async (req: HttpRequest, retries = MAX_RETRY): Promis
 
         response.on('error', (error) => {
           if (retries > 0) {
-            console.warn({msg: localRequest.url}, `Downstream response failed. Retrying after 500ms...`)
+            console.warn({msg: localRequest.url, requestId, interactionId}, `Downstream response failed. Retrying after 500ms...`)
             setTimeout(() => {
               resolve(makeRequest(localRequest, retries - 1))
             }, 500) // Wait for 0.5 second before retrying
           } else {
-            console.error({error}, `Error getting response from downstream. Giving up after ${MAX_RETRY} retries.`)
+            console.error({error, requestId, interactionId}, `Error getting response from downstream. Giving up after ${MAX_RETRY} retries.`)
             reject(error)
           }
         })
       })
       request.on('error', (error) => {
-        console.error({error}, 'Error making request to downstream.')
+        console.error({error, requestId, interactionId}, 'Error making request to downstream.')
         reject(error)
       })
       if (localRequest.body) {

--- a/test/common/rest-helpers.test.ts
+++ b/test/common/rest-helpers.test.ts
@@ -1,0 +1,22 @@
+import {getCommonHeaders} from '../../src/common/rest-helpers'
+import {expect} from 'chai'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('getCommonHeaders', () => {
+  it('includes Content-Type', () => {
+    const headers = getCommonHeaders()
+    expect(headers['Content-Type']).to.equal('application/vnd.api+json')
+  })
+
+  it('includes SNYK-INTERACTION-ID as a valid UUID', () => {
+    const headers = getCommonHeaders()
+    expect(headers['SNYK-INTERACTION-ID']).to.match(UUID_REGEX)
+  })
+
+  it('returns the same SNYK-INTERACTION-ID across multiple calls', () => {
+    const first = getCommonHeaders()['SNYK-INTERACTION-ID']
+    const second = getCommonHeaders()['SNYK-INTERACTION-ID']
+    expect(first).to.equal(second)
+  })
+})

--- a/test/utils/http-request.test.ts
+++ b/test/utils/http-request.test.ts
@@ -1,0 +1,64 @@
+import {makeRequest, HttpRequest} from '../../src/utils/http-request'
+import {expect} from 'chai'
+import nock from 'nock'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('makeRequest SNYK-REQUEST-ID injection', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('injects SNYK-REQUEST-ID as a valid UUID', async () => {
+    nock('https://example.com').get('/test').reply(200, '{}')
+
+    const req: HttpRequest = {
+      url: 'https://example.com/test',
+      headers: {'Content-Type': 'application/json'},
+      method: 'GET',
+    }
+
+    await makeRequest(req, 0)
+    const injectedId = (req.headers as Record<string, string>)['SNYK-REQUEST-ID']
+    expect(injectedId).to.match(UUID_REGEX)
+  })
+
+  it('uses different SNYK-REQUEST-ID for separate calls', async () => {
+    nock('https://example.com').get('/test').times(2).reply(200, '{}')
+
+    const req1: HttpRequest = {
+      url: 'https://example.com/test',
+      headers: {'Content-Type': 'application/json'},
+      method: 'GET',
+    }
+    const req2: HttpRequest = {
+      url: 'https://example.com/test',
+      headers: {'Content-Type': 'application/json'},
+      method: 'GET',
+    }
+
+    await makeRequest(req1, 0)
+    await makeRequest(req2, 0)
+
+    const id1 = (req1.headers as Record<string, string>)['SNYK-REQUEST-ID']
+    const id2 = (req2.headers as Record<string, string>)['SNYK-REQUEST-ID']
+    expect(id1).to.match(UUID_REGEX)
+    expect(id2).to.match(UUID_REGEX)
+    expect(id1).to.not.equal(id2)
+  })
+
+  it('does not overwrite a pre-existing SNYK-REQUEST-ID', async () => {
+    const existingId = '11111111-1111-1111-1111-111111111111'
+    nock('https://example.com').get('/test').reply(200, '{}')
+
+    const req: HttpRequest = {
+      url: 'https://example.com/test',
+      headers: {'Content-Type': 'application/json', 'SNYK-REQUEST-ID': existingId},
+      method: 'GET',
+    }
+
+    await makeRequest(req, 0)
+    const id = (req.headers as Record<string, string>)['SNYK-REQUEST-ID']
+    expect(id).to.equal(existingId)
+  })
+})


### PR DESCRIPTION
There's an established practise in the Snyk/CLI to provide an interaction id (snyk-interaction-id in headers) on "flows". And a snyk-request-id header on unique requests.

This change follows this established pattern to help troubleshooting when things go wrong with the tool.

This will allow us to look for logs relating to the interaction id on the server side and see exactly which of the requests failed, as well as provide us with the diagnostics to identify why that unique request may have failed.