### PR TITLE
fix: relax hostname check to accept underscores and internal hostnames [ACC-3354]

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -5,7 +5,7 @@ export function isValidUUID(val: string): boolean {
 
 export function isValidHostnameWithPort(hostname: string): boolean {
   const regex =
-    /^(?!:\/\/)([\dA-Za-z-]{1,63})(\.[\dA-Za-z-]{1,63})*(\.[A-Za-z]{2,6})?(:\d{1,5})?(\/[\w!$%&'()*+,./:;=@~-]*)?$/
+    /^\w(?:[\w-]{0,61}\w)?(?:\.\w(?:[\w-]{0,61}\w)?)*(?::\d{1,5})?(?:\/[\w!$%&'()*+,./:;=@~-]*)?$/
   return regex.test(hostname)
 }
 

--- a/test/utils/validation.test.ts
+++ b/test/utils/validation.test.ts
@@ -1,30 +1,92 @@
 import {expect} from 'chai'
-import {stripTrailingSlash} from '../../src/utils/validation'
+import {isValidHostnameWithPort, stripTrailingSlash} from '../../src/utils/validation'
 
-describe('stripTrailingSlash', () => {
-  it('strips a single trailing slash', () => {
-    expect(stripTrailingSlash('https://example.com/')).to.equal('https://example.com')
+describe('validation', () => {
+  describe('stripTrailingSlash', () => {
+    it('strips a single trailing slash', () => {
+      expect(stripTrailingSlash('https://example.com/')).to.equal('https://example.com')
+    })
+
+    it('is a no-op when no trailing slash is present', () => {
+      expect(stripTrailingSlash('https://example.com')).to.equal('https://example.com')
+    })
+
+    it('strips multiple trailing slashes', () => {
+      expect(stripTrailingSlash('https://example.com//')).to.equal('https://example.com')
+    })
+
+    it('preserves a path while stripping its trailing slash', () => {
+      expect(stripTrailingSlash('https://example.com/path/')).to.equal('https://example.com/path')
+    })
+
+    it('does not strip the protocol slashes for a bare scheme', () => {
+      expect(stripTrailingSlash('https://')).to.equal('https://')
+    })
+
+    it('is a no-op for UUID-style strings', () => {
+      expect(stripTrailingSlash('123e4567-e89b-42d3-a456-426614174000')).to.equal(
+        '123e4567-e89b-42d3-a456-426614174000',
+      )
+    })
   })
 
-  it('is a no-op when no trailing slash is present', () => {
-    expect(stripTrailingSlash('https://example.com')).to.equal('https://example.com')
-  })
+  describe('isValidHostnameWithPort', () => {
+    describe('valid hostnames', () => {
+      const valid = [
+        'localhost',
+        'example.com',
+        'sub.domain.example.com',
+        'sub_domain.example.com',
+        'sub-domain.example.com',
+        'host123.example.com',
+        '123host.example.com',
+      ]
+      for (const host of valid) {
+        it(`accepts "${host}"`, () => {
+          expect(isValidHostnameWithPort(host)).to.equal(true)
+        })
+      }
+    })
 
-  it('strips multiple trailing slashes', () => {
-    expect(stripTrailingSlash('https://example.com//')).to.equal('https://example.com')
-  })
+    describe('valid hostnames with port', () => {
+      const valid = [
+        'example.com:80',
+        'sub.domain.example.com:8080',
+        'sub_domain.example.com:5555',
+        'sub-domain.example.com:7777',
+        'host.example.com:65535',
+      ]
+      for (const host of valid) {
+        it(`accepts "${host}"`, () => {
+          expect(isValidHostnameWithPort(host)).to.equal(true)
+        })
+      }
+    })
 
-  it('preserves a path while stripping its trailing slash', () => {
-    expect(stripTrailingSlash('https://example.com/path/')).to.equal('https://example.com/path')
-  })
+    describe('invalid hostnames', () => {
+      const invalid = [
+        '',
+        '-foo.com',
+        'foo-.com',
+        'foo..com',
+        '.foo.com',
+        'foo.com.',
+        'foo.com:',
+        'foo.com:abc',
+        'https://github.com',
+        'http://example.com',
+        'foo bar.com',
+        'foo@bar.com',
+      ]
+      for (const host of invalid) {
+        it(`rejects "${host}"`, () => {
+          expect(isValidHostnameWithPort(host)).to.equal(false)
+        })
+      }
+    })
 
-  it('does not strip the protocol slashes for a bare scheme', () => {
-    expect(stripTrailingSlash('https://')).to.equal('https://')
-  })
-
-  it('is a no-op for UUID-style strings', () => {
-    expect(stripTrailingSlash('123e4567-e89b-42d3-a456-426614174000')).to.equal(
-      '123e4567-e89b-42d3-a456-426614174000',
-    )
+    it('rejects names with label longer than 63 characters', () => {
+      expect(isValidHostnameWithPort('a'.repeat(64) + '.com')).to.equal(false)
+    })
   })
 })


### PR DESCRIPTION
This PR relaxes hostname check function and allows to use underscore. Additionally following improvements are done:
- allow underscores in hostname labels (common in internal/AD DNS)
- clean up the regex: drop the no-op `(?!:\/\/)` lookahead and the redundant TLD group that incorrectly capped TLDs at 6 chars
- hostnames now must start and end with an alphanumeric or underscore, with hyphens only in the middle, still capped at 63 characters per label