### PR TITLE
feat: surface broker app client_id/client_secret from setupFlow

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -43,7 +43,7 @@ export interface AppInstallsResponse {
 export interface AppInstallOutput {
   install_id: string
   client_id: string
-  client_secret: string
+  client_secret?: string
 }
 
 export interface CredentialsAttributes {

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -127,6 +127,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
 
     let orgId
     let installId
+    let clientId
+    let clientSecret
     if (process.env.INSTALL_ID) {
       installId = process.env.INSTALL_ID
     } else if (await confirm({message: 'Have you installed the Broker App against an Org?'})) {
@@ -141,12 +143,13 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
         ValidationType.UUID,
       )
       const appInstall = await installAppsWorfklow(orgId)
-      if (typeof appInstall === 'string') {
-        this.logStatus(ux.colorize('cyan', `Found an App already installed. Using Install ID ${appInstall}.`))
-        installId = appInstall
+      const {install_id, client_id, client_secret} = appInstall
+      installId = install_id
+      clientId = client_id
+      if (!client_secret) {
+        this.logStatus(ux.colorize('cyan', `Found an App already installed. Using Install ID ${installId}.`))
       } else {
-        const {install_id, client_id, client_secret} = appInstall
-        installId = install_id
+        clientSecret = client_secret
         this.logStatus(ux.colorize('cyan', `\n${STATUS.IMPORTANT}`))
         this.logStatus(ux.colorize('cyan', `App installed. Please store the following credentials securely:`))
         this.logStatus(ux.colorize('cyan', `- clientId: ${client_id}`))
@@ -178,7 +181,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       orgId = 'dummy'
     }
     const appInstalledOnOrgId = orgId ?? (await getAppInstalledOnOrgId(tenantId, installId))
-    return {installId, tenantId, appInstalledOnOrgId}
+    return {installId, tenantId, appInstalledOnOrgId, clientId, clientSecret}
   }
 
   async selectDeployment(tenantId: string, installId: string): Promise<DeploymentId> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface SetupParameters {
   installId: string
   tenantId: string
   appInstalledOnOrgId: string
+  clientId?: string
+  clientSecret?: string
 }
 
 export type TenantId = string

--- a/src/workflows/apps.ts
+++ b/src/workflows/apps.ts
@@ -4,10 +4,13 @@ import {AppInstallOutput} from '../api/types.js'
 import {isValidUUID} from '../utils/validation.js'
 import {validatedInput, ValidationType} from '../utils/input-validation.js'
 
-export const installAppsWorfklow = async (orgId: string): Promise<AppInstallOutput | string> => {
+export const installAppsWorfklow = async (orgId: string): Promise<AppInstallOutput> => {
   const existingInstall = await getExistingAppInstalledOnOrgId(orgId)
   if (existingInstall) {
-    return existingInstall.id
+    return {
+      install_id: existingInstall.id,
+      client_id: existingInstall.attributes.client_id,
+    }
   }
   const installData = await installAppIdOnOrgId(orgId)
   return {


### PR DESCRIPTION
Return client_id from both arms of installAppsWorfklow and thread clientId/clientSecret out of setupFlow (from the install-by-org path only) via optional SetupParameters fields. No new API calls and no behaviour change for existing commands - prep for the setup orchestrator.