### PR TITLE
feat: discover broker app install from tenant id

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -64,6 +64,29 @@ export const getDeployments = async (tenantId: string, installId: string) => {
   }
 }
 
+export const getDeploymentsForTenant = async (tenantId: string) => {
+  const headers = {...getCommonHeaders(), ...getAuthHeader()}
+  const apiPath = `rest/tenants/${tenantId}/brokers/deployments`
+  const config = getConfig()
+
+  const req: HttpRequest = {
+    url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
+    headers: headers,
+    method: 'GET',
+    operation: 'list deployments',
+  }
+  try {
+    const response = await makeRequest(req)
+    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+    return JSON.parse(response.body) as DeploymentsResponse
+  } catch (error) {
+    if (error instanceof ApiError && error.statusCode === 404) {
+      return {data: [], errors: [{details: '404'}]}
+    }
+    throw error
+  }
+}
+
 export const createDeployment = async (
   tenantId: string,
   installId: string,

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -2,9 +2,14 @@
 import {Command, Flags, Interfaces, ux} from '@oclif/core'
 import {getConfig} from './config/config.js'
 import {input, confirm, select} from '@inquirer/prompts'
-import {isValidUUID} from './utils/validation.js'
-import {getAppInstalledOnOrgId, installAppsWorfklow} from './workflows/apps.js'
-import {createDeployment, DeploymentAttributes, DeploymentResponse, getDeployments} from './api/deployments.js'
+import {installAppsWorfklow} from './workflows/apps.js'
+import {
+  createDeployment,
+  DeploymentAttributes,
+  DeploymentResponse,
+  getDeployments,
+  getDeploymentsForTenant,
+} from './api/deployments.js'
 import {
   ConnectionId,
   ConnectionSelection,
@@ -85,6 +90,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     } catch (error) {
       this.error(error instanceof Error ? error.message : String(error))
     }
+    let tenantIdPrompted = false
     if (!process.env.TENANT_ID) {
       const accessibleTenants = await getAccessibleTenants()
       if (accessibleTenants.data.length === 0) {
@@ -103,18 +109,21 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
             `Your credentials can access tenants:\n${accessibleTenants.data.map((x) => `- ${x.attributes.name}: ${x.id}`).join(',\n')}.\n`,
           ),
         )
-        this.logStatus(
-          ux.colorize(
-            'cyan',
-            `${STATUS.TIP} export TENANT_ID=${process.env.TENANT_ID} (Windows: set TENANT_ID=${process.env.TENANT_ID}) to avoid inputting this for each command.\n`,
-          ),
-        )
+        tenantIdPrompted = true
       }
     }
 
     const tenantId =
       process.env.TENANT_ID ?? (await validatedInput({message: 'Enter your tenantID.'}, ValidationType.UUID))
     process.env.TENANT_ID = tenantId
+    if (tenantIdPrompted) {
+      this.logStatus(
+        ux.colorize(
+          'cyan',
+          `${STATUS.TIP} export TENANT_ID=${tenantId} (Windows: set TENANT_ID=${tenantId}) to avoid inputting this for each command.\n`,
+        ),
+      )
+    }
 
     try {
       await isTenantAdmin(tenantId, userId)
@@ -134,14 +143,11 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     let installId
     let clientId
     let clientSecret
-    if (process.env.INSTALL_ID) {
-      installId = process.env.INSTALL_ID
-    } else if (await confirm({message: 'Have you installed the Broker App against an Org?'})) {
-      installId = await validatedInput({message: 'Enter your Broker App Install ID'}, ValidationType.UUID)
-      if (!isValidUUID(installId)) {
-        this.error(`Must be a valid UUID.`)
-      }
-      // process.env.INSTALL_ID = installId
+    const discovered = await this.discoverInstallFromTenant(tenantId)
+    if (discovered) {
+      installId = discovered.installId
+      orgId = discovered.appInstalledOnOrgId
+      this.logStatus(ux.colorize('cyan', `Found existing Broker App Install ${installId} configured in this Tenant.`))
     } else {
       orgId = await validatedInput(
         {message: `Enter Org ID to install Broker App. Must be in Tenant ${tenantId}`},
@@ -168,14 +174,6 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
             ),
           )
         }
-        this.logStatus(
-          ux.colorize(
-            'cyan',
-            `\n${STATUS.TIP} For a smoother experience, please set the environment variable listed above.`,
-          ),
-        )
-        this.logStatus(ux.colorize('cyan', `Linux/Mac: export INSTALL_ID=${installId}`))
-        this.logStatus(ux.colorize('cyan', `Windows: set INSTALL_ID=${installId}\n`))
         if (!(await confirm({message: `Continue?`}))) {
           process.exit(0)
         }
@@ -185,8 +183,43 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     if (skipOrgId) {
       orgId = 'dummy'
     }
-    const appInstalledOnOrgId = orgId ?? (await getAppInstalledOnOrgId(tenantId, installId))
+    const appInstalledOnOrgId = orgId
     return {installId, tenantId, appInstalledOnOrgId, clientId, clientSecret}
+  }
+
+  async discoverInstallFromTenant(
+    tenantId: string,
+  ): Promise<{installId: string; appInstalledOnOrgId: string} | undefined> {
+    const deployments = await getDeploymentsForTenant(tenantId)
+    if (!deployments.data || deployments.data.length === 0) {
+      return undefined
+    }
+    // dedupe the deployments down to the distinct installs.
+    const installs = new Map<string, string>()
+    for (const deployment of deployments.data) {
+      if (!installs.has(deployment.attributes.install_id)) {
+        installs.set(deployment.attributes.install_id, deployment.attributes.broker_app_installed_in_org_id)
+      }
+    }
+    const newInstall = 'install-on-new-org'
+    const choice = await select({
+      message: 'Which Broker App Install do you want to use?',
+      choices: [
+        ...[...installs.entries()].map(([installId, orgId]) => ({
+          name: `Install ${installId} (Org ${orgId})`,
+          value: installId,
+        })),
+        {name: 'Create a new Broker App Install on a different Org', value: newInstall},
+      ],
+    })
+    if (choice === newInstall) {
+      return undefined
+    }
+    const appInstalledOnOrgId = installs.get(choice)
+    if (!appInstalledOnOrgId) {
+      return undefined
+    }
+    return {installId: choice, appInstalledOnOrgId}
   }
 
   async selectDeployment(tenantId: string, installId: string): Promise<DeploymentId> {

--- a/src/workflows/apps.ts
+++ b/src/workflows/apps.ts
@@ -1,8 +1,5 @@
 import {getExistingAppInstalledOnOrgId, installAppIdOnOrgId} from '../api/apps.js'
-import {getDeployments} from '../api/deployments.js'
 import {AppInstallOutput} from '../api/types.js'
-import {isValidUUID} from '../utils/validation.js'
-import {validatedInput, ValidationType} from '../utils/input-validation.js'
 
 export const installAppsWorfklow = async (orgId: string): Promise<AppInstallOutput> => {
   const existingInstall = await getExistingAppInstalledOnOrgId(orgId)
@@ -18,19 +15,4 @@ export const installAppsWorfklow = async (orgId: string): Promise<AppInstallOutp
     client_id: installData.data.attributes.client_id,
     client_secret: installData.data.attributes.client_secret,
   }
-}
-
-export const getAppInstalledOnOrgId = async (tenantId: string, installId: string): Promise<string> => {
-  let orgId
-  const deployments = await getDeployments(tenantId, installId)
-  if (deployments.data && deployments.data.length === 0) {
-    orgId = await validatedInput({message: 'Enter the Org ID where you installed your Broker App'}, ValidationType.UUID)
-    if (!isValidUUID(installId)) {
-      throw new Error('Invalid Org ID entered.')
-    }
-  } else {
-    const deploymentsList = deployments.data as Array<any>
-    orgId = deploymentsList[0].attributes.broker_app_installed_in_org_id
-  }
-  return orgId
 }

--- a/test/api/deployments.test.ts
+++ b/test/api/deployments.test.ts
@@ -3,8 +3,10 @@ import {
   deleteDeployment,
   DeploymentAttributesMetadata,
   getDeployments,
+  getDeploymentsForTenant,
   updateDeployment,
 } from '../../src/api/deployments'
+import {ApiError} from '../../src/utils/errors'
 import {expect} from 'chai'
 import nock from 'nock'
 
@@ -71,6 +73,30 @@ describe('Deployments Api calls', () => {
       .reply(() => {
         return [204]
       })
+      .get('/rest/tenants/00000000-0000-0000-0000-000000000000/brokers/deployments?version=2024-10-15')
+      .reply((uri, body) => {
+        const response = apiResponseSchema
+        response.data = [
+          {
+            attributes: {
+              broker_app_installed_in_org_id: '00000000-0000-0000-0000-000000000000',
+              install_id: '00000000-0000-0000-0000-000000000000',
+              metadata: {},
+            },
+            id: '00000000-0000-0000-0000-000000000000',
+            type: 'broker_deployment',
+          },
+        ]
+        return [200, response]
+      })
+      .get('/rest/tenants/00000000-0000-0000-0000-000000000001/brokers/deployments?version=2024-10-15')
+      .reply(() => {
+        return [404, {}]
+      })
+      .get('/rest/tenants/00000000-0000-0000-0000-000000000002/brokers/deployments?version=2024-10-15')
+      .reply(() => {
+        return [500, {}]
+      })
   })
 
   it('getDeployments', async () => {
@@ -92,6 +118,42 @@ describe('Deployments Api calls', () => {
       ],
       links: {},
     })
+  })
+
+  it('getDeploymentsForTenant', async () => {
+    const gotDeployments = await getDeploymentsForTenant('00000000-0000-0000-0000-000000000000')
+    expect(gotDeployments).to.deep.equal({
+      data: [
+        {
+          attributes: {
+            broker_app_installed_in_org_id: '00000000-0000-0000-0000-000000000000',
+            install_id: '00000000-0000-0000-0000-000000000000',
+            metadata: {},
+          },
+          id: '00000000-0000-0000-0000-000000000000',
+          type: 'broker_deployment',
+        },
+      ],
+      links: {},
+    })
+  })
+
+  it('getDeploymentsForTenant returns empty on 404', async () => {
+    const gotDeployments = await getDeploymentsForTenant('00000000-0000-0000-0000-000000000001')
+    expect(gotDeployments).to.deep.equal({data: [], errors: [{details: '404'}]})
+  })
+
+  it('getDeploymentsForTenant rethrows non-404 errors', async () => {
+    let thrown: unknown
+    try {
+      await getDeploymentsForTenant('00000000-0000-0000-0000-000000000002')
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).to.be.instanceOf(ApiError)
+    if (thrown instanceof ApiError) {
+      expect(thrown.statusCode).to.equal(500)
+    }
   })
 
   it('createDeployments', async () => {

--- a/test/test-utils/nock-utils.ts
+++ b/test/test-utils/nock-utils.ts
@@ -13,6 +13,8 @@ export const orgId3 = '3a7c1ab9-8914-4f39-a8c0-5752af653a8a'
 export const orgId4 = '3a7c1ab9-8914-4f39-a8c0-5752af653a8b'
 export const tenantId = '00000000-0000-0000-0000-000000000000'
 export const nonAdminTenantId = '00000000-0000-0000-0000-000000000001'
+export const discoverTenantId = '00000000-0000-0000-0000-0000000000d1'
+export const multiDiscoverTenantId = '00000000-0000-0000-0000-0000000000d2'
 export const installId = '00000000-0000-0000-0000-000000000000'
 export const installId2 = '00000000-0000-0000-0000-000000000002'
 export const installId3 = '00000000-0000-0000-0000-000000000003'
@@ -443,6 +445,96 @@ export const beforeStep = () => {
     )
     .reply(() => {
       return [200, forbiddenTenantMembersResponse]
+    })
+    .get(
+      `/rest/tenants/${discoverTenantId}/memberships?role_name=admin&user_id=${userId}&version=2024-10-14~experimental`,
+    )
+    .reply(() => {
+      return [200, tenantMemberships]
+    })
+    .get(
+      `/rest/tenants/${multiDiscoverTenantId}/memberships?role_name=admin&user_id=${userId}&version=2024-10-14~experimental`,
+    )
+    .reply(() => {
+      return [200, tenantMemberships]
+    })
+    // Tenant-level deployment discovery (GET /rest/tenants/{tenantId}/brokers/deployments)
+    .get(`${urlPrefixTenantId}/brokers/deployments?version=2024-10-15`)
+    .reply(() => {
+      return [200, {data: [], links: {}}]
+    })
+    .get(`/rest/tenants/${discoverTenantId}/brokers/deployments?version=2024-10-15`)
+    .reply(() => {
+      return [
+        200,
+        {
+          data: [
+            {
+              attributes: {broker_app_installed_in_org_id: orgId, install_id: installId, metadata: {}},
+              id: deploymentId,
+              type: 'broker_deployment',
+            },
+          ],
+          links: {},
+        },
+      ]
+    })
+    .get(`/rest/tenants/${multiDiscoverTenantId}/brokers/deployments?version=2024-10-15`)
+    .reply(() => {
+      return [
+        200,
+        {
+          data: [
+            {
+              attributes: {broker_app_installed_in_org_id: orgId, install_id: installId, metadata: {}},
+              id: deploymentId,
+              type: 'broker_deployment',
+            },
+            {
+              attributes: {broker_app_installed_in_org_id: orgId2, install_id: installId2, metadata: {}},
+              id: deploymentId2,
+              type: 'broker_deployment',
+            },
+          ],
+          links: {},
+        },
+      ]
+    })
+    .post(`/rest/tenants/${discoverTenantId}/brokers/installs/${installId}/deployments?version=2024-10-15`)
+    .reply((uri, body) => {
+      return [
+        200,
+        {
+          data: {
+            attributes: {
+              broker_app_installed_in_org_id: orgId,
+              install_id: installId,
+              metadata: {key: 'value'},
+            },
+            id: deploymentId,
+            type: 'broker_deployment',
+          },
+          links: {},
+        },
+      ]
+    })
+    .post(`/rest/tenants/${multiDiscoverTenantId}/brokers/installs/${installId2}/deployments?version=2024-10-15`)
+    .reply((uri, body) => {
+      return [
+        200,
+        {
+          data: {
+            attributes: {
+              broker_app_installed_in_org_id: orgId2,
+              install_id: installId2,
+              metadata: {key: 'value'},
+            },
+            id: deploymentId2,
+            type: 'broker_deployment',
+          },
+          links: {},
+        },
+      ]
     })
     .get(`${urlPrefixTenantIdAndInstallId}/deployments?version=2024-10-15`)
     .reply((uri, body) => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "composite": false,
+    "rootDir": ".",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node", "mocha"]
   },
-  "references": [
-    {"path": ".."}
-  ]
+  "include": ["./**/*.ts"],
+  "references": [{"path": ".."}]
 }

--- a/test/workflows/connections/bulk-migration-apply.test.ts
+++ b/test/workflows/connections/bulk-migration-apply.test.ts
@@ -45,13 +45,16 @@ describe('connections bulk-migration apply workflow', () => {
 
   it('runs connections:bulk-migration:apply and successfully starts migration', async () => {
     process.env.TENANT_ID = successTestTenantId
-    process.env.INSTALL_ID = successTestInstallId
 
     // @ts-ignore
     const cfg: Config = {}
     const command = new BulkMigrationApplyCommand([], cfg)
 
     // Mock selection methods
+    command.discoverInstallFromTenant = async () => ({
+      installId: successTestInstallId,
+      appInstalledOnOrgId: successTestTenantId,
+    })
     command.selectDeployment = async () => successTestDeploymentId
     command.selectConnection = async () => ({
       id: successTestConnectionId,
@@ -75,7 +78,6 @@ describe('connections bulk-migration apply workflow', () => {
 
   it('runs connections:bulk-migration:apply and handles API error', async () => {
     process.env.TENANT_ID = errorTestTenantId
-    process.env.INSTALL_ID = errorTestInstallId
     const errorMessage = 'Internal Server Error For Test'
     const errorDetail = 'Something went terribly wrong during apply for test.'
 
@@ -83,6 +85,10 @@ describe('connections bulk-migration apply workflow', () => {
     const cfg: Config = {}
     const command = new BulkMigrationApplyCommand([], cfg)
 
+    command.discoverInstallFromTenant = async () => ({
+      installId: errorTestInstallId,
+      appInstalledOnOrgId: errorTestTenantId,
+    })
     command.selectDeployment = async () => errorTestDeploymentId
     command.selectConnection = async () => ({
       id: errorTestConnectionId,

--- a/test/workflows/connections/bulk-migration-list-no-orgs.test.ts
+++ b/test/workflows/connections/bulk-migration-list-no-orgs.test.ts
@@ -19,7 +19,6 @@ describe('connections bulk-migration list workflow - no orgs', () => {
     beforeStep()
     process.env.SNYK_TOKEN = snykToken
     process.env.TENANT_ID = testTenantId
-    process.env.INSTALL_ID = testInstallId
   })
 
   after(() => {
@@ -27,7 +26,6 @@ describe('connections bulk-migration list workflow - no orgs', () => {
     stdin.restore()
     delete process.env.SNYK_TOKEN
     delete process.env.TENANT_ID
-    delete process.env.INSTALL_ID
   })
 
   it('runs connections:bulk-migration:list and displays no organizations message', async () => {
@@ -35,6 +33,7 @@ describe('connections bulk-migration list workflow - no orgs', () => {
     const cfg: Config = {}
 
     const command = new BulkMigrationListCommand([], cfg)
+    command.discoverInstallFromTenant = async () => ({installId: testInstallId, appInstalledOnOrgId: testTenantId})
 
     const {stdout, stderr, error} = await captureOutput(async () => {
       sendScenario(stdin, [])

--- a/test/workflows/connections/bulk-migration-list-orgs.test.ts
+++ b/test/workflows/connections/bulk-migration-list-orgs.test.ts
@@ -20,7 +20,6 @@ describe('connections bulk-migration list workflow - with orgs', () => {
     beforeStep()
     process.env.SNYK_TOKEN = snykToken
     process.env.TENANT_ID = testTenantId
-    process.env.INSTALL_ID = testInstallId
   })
 
   after(() => {
@@ -28,7 +27,6 @@ describe('connections bulk-migration list workflow - with orgs', () => {
     stdin.restore()
     delete process.env.SNYK_TOKEN
     delete process.env.TENANT_ID
-    delete process.env.INSTALL_ID
   })
 
   it('runs connections:bulk-migration:list and displays organizations', async () => {
@@ -36,6 +34,7 @@ describe('connections bulk-migration list workflow - with orgs', () => {
     const cfg: Config = {}
 
     const command = new BulkMigrationListCommand([], cfg)
+    command.discoverInstallFromTenant = async () => ({installId: testInstallId, appInstalledOnOrgId: testTenantId})
 
     const {stdout, stderr, error} = await captureOutput(async () => {
       sendScenario(stdin, [])

--- a/test/workflows/connections/create.test.ts
+++ b/test/workflows/connections/create.test.ts
@@ -19,8 +19,6 @@ describe('connection workflows', () => {
         sendScenarioWithOutAutoEnter(stdin, [
           snykToken,
           '\n',
-          'n',
-          '\n',
           orgId,
           '\n',
           downArrow,

--- a/test/workflows/connections/delete-after-disconnect.test.ts
+++ b/test/workflows/connections/delete-after-disconnect.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, downArrow, 'y', 'y', 'y'])
+        sendScenario(stdin, [snykToken, orgId4, downArrow, 'y', 'y', 'y'])
 
         return deleteConnection.run()
       },

--- a/test/workflows/connections/delete-fail-due-to-integrations.test.ts
+++ b/test/workflows/connections/delete-fail-due-to-integrations.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, downArrow, 'n'])
+        sendScenario(stdin, [snykToken, orgId4, downArrow, 'n'])
 
         return deleteConnection.run()
       },

--- a/test/workflows/connections/delete.test.ts
+++ b/test/workflows/connections/delete.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3, 'y'])
+        sendScenario(stdin, [snykToken, orgId3, 'y'])
 
         return deleteConnection.run()
       },

--- a/test/workflows/connections/disconnect-without-integration.test.ts
+++ b/test/workflows/connections/disconnect-without-integration.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const disconnectConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3])
+        sendScenario(stdin, [snykToken, orgId3])
         return disconnectConnection.run()
       },
       {print: false},

--- a/test/workflows/connections/disconnect.test.ts
+++ b/test/workflows/connections/disconnect.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const disconnectConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, downArrow, tab, 'y'])
+        sendScenario(stdin, [snykToken, orgId4, downArrow, tab, 'y'])
         return disconnectConnection.run()
       },
       {print: false},

--- a/test/workflows/connections/get-empty.test.ts
+++ b/test/workflows/connections/get-empty.test.ts
@@ -16,7 +16,7 @@ describe('connections workflows', () => {
     const getConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId2])
+        sendScenario(stdin, [snykToken, orgId2])
 
         return getConnection.run()
       },

--- a/test/workflows/connections/get.test.ts
+++ b/test/workflows/connections/get.test.ts
@@ -16,7 +16,7 @@ describe('connections workflows', () => {
     const getConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3])
+        sendScenario(stdin, [snykToken, orgId3])
 
         return getConnection.run()
       },

--- a/test/workflows/connections/integrate-non-source-integration.test.ts
+++ b/test/workflows/connections/integrate-non-source-integration.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const integrateConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, orgId4, orgId4, 'y'])
+        sendScenario(stdin, [snykToken, orgId4, orgId4, orgId4, 'y'])
         return integrateConnection.run()
       },
       {print: false},

--- a/test/workflows/connections/integrate.test.ts
+++ b/test/workflows/connections/integrate.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const integrateConnection = new Connections([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3, orgId3, integrationId3])
+        sendScenario(stdin, [snykToken, orgId3, orgId3, integrationId3])
         return integrateConnection.run()
       },
       {print: false},

--- a/test/workflows/connections/update.test.ts
+++ b/test/workflows/connections/update.test.ts
@@ -22,8 +22,6 @@ describe('connection update workflow', () => {
         sendScenarioWithOutAutoEnter(stdin, [
           snykToken,
           '\n',
-          'n',
-          '\n',
           orgId4,
           '\n',
           '\n',

--- a/test/workflows/contexts/apply.test.ts
+++ b/test/workflows/contexts/apply.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const apply = new Contexts([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, tab])
+        sendScenario(stdin, [snykToken, orgId4, tab])
         return apply.run()
       },
       {print: false},

--- a/test/workflows/contexts/create.test.ts
+++ b/test/workflows/contexts/create.test.ts
@@ -19,8 +19,6 @@ describe('context workflows', () => {
         sendScenarioWithOutAutoEnter(stdin, [
           snykToken,
           '\n',
-          'n',
-          '\n',
           orgId3,
           '\n',
           tab,

--- a/test/workflows/contexts/delete.test.ts
+++ b/test/workflows/contexts/delete.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteConnection = new Contexts([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3, 'y'])
+        sendScenario(stdin, [snykToken, orgId3, 'y'])
 
         return deleteConnection.run()
       },

--- a/test/workflows/contexts/get.test.ts
+++ b/test/workflows/contexts/get.test.ts
@@ -16,7 +16,7 @@ describe('contexts workflows', () => {
     const getContext = new Contexts([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3])
+        sendScenario(stdin, [snykToken, orgId3])
 
         return getContext.run()
       },

--- a/test/workflows/contexts/list.test.ts
+++ b/test/workflows/contexts/list.test.ts
@@ -16,7 +16,7 @@ describe('contexts workflows', () => {
     const listContext = new Contexts([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3])
+        sendScenario(stdin, [snykToken, orgId3])
 
         return listContext.run()
       },

--- a/test/workflows/contexts/usage.test.ts
+++ b/test/workflows/contexts/usage.test.ts
@@ -16,7 +16,7 @@ describe('contexts workflows', () => {
     const getContext = new Contexts([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3])
+        sendScenario(stdin, [snykToken, orgId3])
 
         return getContext.run()
       },

--- a/test/workflows/contexts/withdraw.test.ts
+++ b/test/workflows/contexts/withdraw.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const withdraw = new Contexts([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, tab, 'y'])
+        sendScenario(stdin, [snykToken, orgId4, tab, 'y'])
         return withdraw.run()
       },
       {print: false},

--- a/test/workflows/credentials/create.test.ts
+++ b/test/workflows/credentials/create.test.ts
@@ -16,7 +16,7 @@ describe('credentials workflows', () => {
     const createCredentials = new Credentials([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId, downArrow, 'ARTIFACTORY_CR_CREDS_ENV_VAR', 'test env var name'])
+        sendScenario(stdin, [snykToken, orgId, downArrow, 'ARTIFACTORY_CR_CREDS_ENV_VAR', 'test env var name'])
         return createCredentials.run()
       },
       {print: false},

--- a/test/workflows/credentials/delete.test.ts
+++ b/test/workflows/credentials/delete.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteCredentials = new Credentials([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId, 'y', 'y'])
+        sendScenario(stdin, [snykToken, orgId, 'y', 'y'])
 
         return deleteCredentials.run()
       },

--- a/test/workflows/credentials/get.test.ts
+++ b/test/workflows/credentials/get.test.ts
@@ -16,7 +16,7 @@ describe('credentials workflows', () => {
     const getCredentials = new Credentials([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId])
+        sendScenario(stdin, [snykToken, orgId])
         return getCredentials.run()
       },
       {print: false},

--- a/test/workflows/deployments/create-discover.test.ts
+++ b/test/workflows/deployments/create-discover.test.ts
@@ -1,0 +1,95 @@
+import {captureOutput} from '@oclif/test'
+import {expect} from 'chai'
+import {stdin as fstdin} from 'mock-stdin'
+import nock from 'nock'
+import {Config} from '@oclif/core'
+
+import Deployments from '../../../src/commands/workflows/deployments/create'
+import {
+  beforeStep,
+  discoverTenantId,
+  downArrow,
+  installId,
+  installId2,
+  multiDiscoverTenantId,
+  orgId,
+  orgId2,
+  snykToken,
+} from '../../test-utils/nock-utils'
+import {sendScenario} from '../../test-utils/stdin-utils'
+
+describe('deployment create workflow - tenant install discovery', () => {
+  let stdin: ReturnType<typeof fstdin>
+
+  beforeEach(() => {
+    stdin = fstdin()
+    beforeStep()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    stdin.restore()
+    delete process.env.SNYK_TOKEN
+    delete process.env.TENANT_ID
+  })
+
+  it('uses the discovered install without prompting for an Org ID', async () => {
+    process.env.TENANT_ID = discoverTenantId
+    // @ts-ignore
+    const cfg: Config = {}
+    const command = new Deployments([], cfg)
+
+    const {stdout, stderr, error} = await captureOutput(async () => {
+      // token, then '' selects the first (and only) discovered install, 'n' declines metadata
+      sendScenario(stdin, [snykToken, '', 'n'])
+      return command.run()
+    })
+
+    expect(error).to.be.undefined
+    expect(stderr).to.contain(`Found existing Broker App Install ${installId}`)
+    expect(stderr).not.to.contain('Enter Org ID')
+    expect(stdout).to.contain(`install_id: ${installId}`)
+    expect(stdout).to.contain(`broker_app_installed_in_org_id: ${orgId}`)
+    expect(stderr).to.contain('Deployment Create Workflow completed.')
+  })
+
+  it('selects among multiple discovered installs', async () => {
+    process.env.TENANT_ID = multiDiscoverTenantId
+    // @ts-ignore
+    const cfg: Config = {}
+    const command = new Deployments([], cfg)
+
+    const {stdout, stderr, error} = await captureOutput(async () => {
+      // token, then downArrow moves to the second discovered install, 'n' declines metadata
+      sendScenario(stdin, [snykToken, downArrow, 'n'])
+      return command.run()
+    })
+
+    expect(error).to.be.undefined
+    expect(stderr).to.contain(`Found existing Broker App Install ${installId2}`)
+    expect(stderr).not.to.contain('Enter Org ID')
+    expect(stdout).to.contain(`install_id: ${installId2}`)
+    expect(stdout).to.contain(`broker_app_installed_in_org_id: ${orgId2}`)
+    expect(stderr).to.contain('Deployment Create Workflow completed.')
+  })
+
+  it('falls back to the Org ID prompt via the escape hatch', async () => {
+    process.env.TENANT_ID = discoverTenantId
+    // @ts-ignore
+    const cfg: Config = {}
+    const command = new Deployments([], cfg)
+
+    const {stdout, stderr, error} = await captureOutput(async () => {
+      // token, then downArrow selects "Install the Broker App on a different Org", enter the org, decline metadata
+      sendScenario(stdin, [snykToken, downArrow, orgId, 'n'])
+      return command.run()
+    })
+
+    expect(error).to.be.undefined
+    // Escape hatch was taken: discovery was NOT used, the org-install path was.
+    expect(stderr).not.to.contain('Found existing Broker App Install')
+    expect(stderr).to.contain('Found an App already installed')
+    expect(stdout).to.contain(`install_id: ${installId}`)
+    expect(stderr).to.contain('Deployment Create Workflow completed.')
+  })
+})

--- a/test/workflows/deployments/create.test.ts
+++ b/test/workflows/deployments/create.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const createDeployment = new Deployments([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId, 'y', 'key', 'value', 'n'])
+        sendScenario(stdin, [snykToken, orgId, 'y', 'key', 'value', 'n'])
         return createDeployment.run()
       },
       {print: false},

--- a/test/workflows/deployments/delete-fails-due-to-conns.test.ts
+++ b/test/workflows/deployments/delete-fails-due-to-conns.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteDeployment = new Deployments([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId3, 'y'])
+        sendScenario(stdin, [snykToken, orgId3, 'y'])
 
         return deleteDeployment.run()
       },

--- a/test/workflows/deployments/delete-fails-due-to-creds.test.ts
+++ b/test/workflows/deployments/delete-fails-due-to-creds.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteDeployment = new Deployments([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId, 'y'])
+        sendScenario(stdin, [snykToken, orgId, 'y'])
 
         return deleteDeployment.run()
       },

--- a/test/workflows/deployments/delete.test.ts
+++ b/test/workflows/deployments/delete.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const deleteDeployment = new Deployments([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId2, 'y'])
+        sendScenario(stdin, [snykToken, orgId2, 'y'])
 
         return deleteDeployment.run()
       },

--- a/test/workflows/deployments/get-failed-due-to-tenant-role.test.ts
+++ b/test/workflows/deployments/get-failed-due-to-tenant-role.test.ts
@@ -20,7 +20,7 @@ describe('deployment workflows', () => {
     const getDeployment = new Deployments([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId])
+        sendScenario(stdin, [snykToken, orgId])
 
         return getDeployment.run()
       },

--- a/test/workflows/deployments/get.test.ts
+++ b/test/workflows/deployments/get.test.ts
@@ -16,7 +16,7 @@ describe('deployment workflows', () => {
     const getDeployment = new Deployments([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId])
+        sendScenario(stdin, [snykToken, orgId])
 
         return getDeployment.run()
       },

--- a/test/workflows/integrations/get.test.ts
+++ b/test/workflows/integrations/get.test.ts
@@ -16,7 +16,7 @@ describe('integrations workflows', () => {
     const getIntegrations = new Integrations([], cfg)
     const {stdout, stderr, error} = await captureOutput(
       async () => {
-        sendScenario(stdin, [snykToken, 'n', orgId4, downArrow])
+        sendScenario(stdin, [snykToken, orgId4, downArrow])
 
         return getIntegrations.run()
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,14 @@
     "strict": true,
     "target": "es2022",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
-    "moduleResolution": "node16"
+    "moduleResolution": "node16",
+    "types": ["node"]
   },
   "include": ["./src/**/*"],
   "ts-node": {
-    "esm": true
+    "esm": true,
+    "compilerOptions": {
+      "types": ["node", "mocha"]
+    }
   }
 }


### PR DESCRIPTION
Replace the prompt for a customer to provide an existing install id with API-based discovery or create a new broker install.

Also update the TS config for local development to make sure the test files show the types in IDE.

Example workflow:
```
Universal Broker - Create Deployment Workflow
? Enter your Snyk Token <token>

TIP: For a smoother experience, please set the Snyk Token as env variable.
Linux/Mac: export SNYK_TOKEN=<token>
Windows: set SNYK_TOKEN=<token>

[OK] Valid Snyk Token for user 5962e60b-0e4b-4508-9340-151edaaef157.
Your credentials can access tenants:
- Environment Testing: 5f5916fa-552e-42a7-8fc8-9068fc361e6d,
- carrie.wiseman: 8378c6c6-9197-45dc-9344-edfb330cf062,
- Snyk Dev Okta SSO Group: 6d5ab730-2455-4cd8-aad9-dc12a70e1c90,
- Team Access: 251a5c45-7d26-4e4a-b59e-a3175d411e50.

? Enter your tenantID.. (Must be a valid uuid). 251a5c45-7d26-4e4a-b59e-a3175d411e50
TIP: export TENANT_ID=251a5c45-7d26-4e4a-b59e-a3175d411e50 (Windows: set TENANT_ID=251a5c45-7d26-4e4a-b59e-a3175d411e50) to avoid inputting this for each command.

[OK] Tenant Admin role confirmed.
? Which Broker App Install do you want to use?
  Install f2b721b2-6578-4d7e-a00d-543052014dac (Org 4ad6c21c-0571-4bb9-a80a-371bdabc859e)
❯ Create a new Broker App Install on a different Org
```