### PR TITLE
refactor: centralize API error handling and standardize output

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -2,7 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
-import {NotFoundError} from '../utils/api-error.js'
+import {ApiError} from '../utils/errors.js'
 import {createLogger} from '../utils/logger.js'
 import {AppInstallResponse, AppInstallResponseData, AppInstallsResponse} from './types.js'
 
@@ -72,7 +72,7 @@ export const getExistingAppInstalledOnOrgId = async (orgId: string): Promise<App
 
     return installs.data.find((x) => x.relationships.app.data.id === appId)
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ApiError && error.statusCode === 404) {
       return undefined
     }
     throw error

--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -2,6 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
+import {NotFoundError} from '../utils/api-error.js'
 import {createLogger} from '../utils/logger.js'
 import {AppInstallResponse, AppInstallResponseData, AppInstallsResponse} from './types.js'
 
@@ -33,19 +34,21 @@ export const installAppIdOnOrgId = async (orgId: string): Promise<AppInstallResp
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'install the Broker App',
   }
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body)
   } catch (error: any) {
-    if (error.includes('HTTP 404: Not Found: app not found')) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (message.includes('app not found')) {
       throw new Error(`Unable to find the app ID.
         For pre-prod environments, set the environment variable SNYK_BROKER_APP_ID=921020b6-b167-426e-867b-3e2856a2f56e.
         For snykgov environments, please contact support.
         `)
     }
-    throw new Error(error)
+    throw error
   }
 }
 
@@ -60,16 +63,18 @@ export const getExistingAppInstalledOnOrgId = async (orgId: string): Promise<App
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.APP_INSTALL_API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'look up the installed Broker App',
   }
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     const installs = JSON.parse(response.body) as AppInstallsResponse
 
-    const existingInstall = installs.data.find((x) => x.relationships.app.data.id === appId)
-
-    return existingInstall
-  } catch (error: any) {
-    throw new Error(error)
+    return installs.data.find((x) => x.relationships.app.data.id === appId)
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return undefined
+    }
+    throw error
   }
 }

--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -2,7 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
-import {NotFoundError} from '../utils/api-error.js'
+import {ApiError} from '../utils/errors.js'
 import {createLogger} from '../utils/logger.js'
 import {
   ConnectionResponse,
@@ -29,7 +29,7 @@ export const getConnectionsForDeployment = async (tenantId: string, installId: s
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as ConnectionsResponse
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ApiError && error.statusCode === 404) {
       return {data: [], jsonapi: {version: ''}, links: {}}
     }
     throw error

--- a/src/api/connections.ts
+++ b/src/api/connections.ts
@@ -2,6 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
+import {NotFoundError} from '../utils/api-error.js'
 import {createLogger} from '../utils/logger.js'
 import {
   ConnectionResponse,
@@ -21,16 +22,17 @@ export const getConnectionsForDeployment = async (tenantId: string, installId: s
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'list connections',
   }
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    if (response.statusCode && response.statusCode === 404) {
+    return JSON.parse(response.body) as ConnectionsResponse
+  } catch (error) {
+    if (error instanceof NotFoundError) {
       return {data: [], jsonapi: {version: ''}, links: {}}
     }
-    return JSON.parse(response.body) as ConnectionsResponse
-  } catch (error: any) {
-    throw new Error(error)
+    throw error
   }
 }
 
@@ -55,14 +57,11 @@ export const applyBulkMigration = async (
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'start bulk migration',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as applyBulkMigrationResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as applyBulkMigrationResponse
 }
 
 export const getBulkMigrationOrgs = async (
@@ -79,14 +78,11 @@ export const getBulkMigrationOrgs = async (
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'list bulk migration orgs',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as GetOrgsForBulkMigrationResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as GetOrgsForBulkMigrationResponse
 }
 
 export const createConnectionForDeployment = async (
@@ -121,15 +117,12 @@ export const createConnectionForDeployment = async (
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'create the connection',
   }
 
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as ConnectionResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as ConnectionResponse
 }
 
 export const updateConnectionForDeployment = async (
@@ -165,14 +158,11 @@ export const updateConnectionForDeployment = async (
     headers: headers,
     method: 'PATCH',
     body: JSON.stringify(body),
+    operation: 'update the connection',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return response.body
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return response.body
 }
 
 export const deleteConnectionForDeployment = async (
@@ -189,13 +179,10 @@ export const deleteConnectionForDeployment = async (
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'DELETE',
+    operation: 'delete the connection',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
 
-    return response.statusCode
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  return response.statusCode
 }

--- a/src/api/contexts.ts
+++ b/src/api/contexts.ts
@@ -2,6 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
+import {NotFoundError} from '../utils/api-error.js'
 import {createLogger} from '../utils/logger.js'
 import {ApplyContextResponse, ContextResponse, ContextsResponse} from './types.js'
 
@@ -16,13 +17,17 @@ export const getContextsForForDeployment = async (tenantId: string, installId: s
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'list contexts',
   }
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as ContextsResponse
-  } catch (error: any) {
-    throw new Error(error)
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return {data: [], jsonapi: {version: ''}, links: {}}
+    }
+    throw error
   }
 }
 
@@ -51,15 +56,12 @@ export const createContextForConnection = async (
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'create the context',
   }
 
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as ContextResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as ContextResponse
 }
 
 export const deleteContextById = async (tenantId: string, installId: string, contextId: string) => {
@@ -71,15 +73,12 @@ export const deleteContextById = async (tenantId: string, installId: string, con
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'DELETE',
+    operation: 'delete the context',
   }
 
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return response.statusCode
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return response.statusCode
 }
 
 export const applyContext = async (tenantId: string, installId: string, contextId: string, orgId: string) => {
@@ -102,15 +101,12 @@ export const applyContext = async (tenantId: string, installId: string, contextI
     headers: headers,
     method: 'PATCH',
     body: JSON.stringify(body),
+    operation: 'apply the context',
   }
 
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as ApplyContextResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as ApplyContextResponse
 }
 
 export const withdrawContext = async (
@@ -127,13 +123,10 @@ export const withdrawContext = async (
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'DELETE',
+    operation: 'withdraw the context',
   }
 
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return response.statusCode
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return response.statusCode
 }

--- a/src/api/contexts.ts
+++ b/src/api/contexts.ts
@@ -2,7 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
-import {NotFoundError} from '../utils/api-error.js'
+import {ApiError} from '../utils/errors.js'
 import {createLogger} from '../utils/logger.js'
 import {ApplyContextResponse, ContextResponse, ContextsResponse} from './types.js'
 
@@ -24,7 +24,7 @@ export const getContextsForForDeployment = async (tenantId: string, installId: s
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as ContextsResponse
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ApiError && error.statusCode === 404) {
       return {data: [], jsonapi: {version: ''}, links: {}}
     }
     throw error

--- a/src/api/credentials.ts
+++ b/src/api/credentials.ts
@@ -2,6 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
+import {NotFoundError} from '../utils/api-error.js'
 import {createLogger} from '../utils/logger.js'
 import {
   CredentialsAttributes,
@@ -22,16 +23,17 @@ export const getCredentialsForDeployment = async (tenantId: string, installId: s
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'list credentials',
   }
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    if (response.statusCode && response.statusCode === 404) {
+    return JSON.parse(response.body) as CredentialsListResponse
+  } catch (error) {
+    if (error instanceof NotFoundError) {
       return {data: [], jsonapi: {version: ''}, links: {}}
     }
-    return JSON.parse(response.body) as CredentialsListResponse
-  } catch (error: any) {
-    throw new Error(error)
+    throw error
   }
 }
 
@@ -49,14 +51,11 @@ export const getCredentialForDeployment = async (
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'get the credential',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as CredentialsResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as CredentialsResponse
 }
 
 export const createCredentials = async (
@@ -79,14 +78,11 @@ export const createCredentials = async (
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'create credentials',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as NewCredentialsResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as NewCredentialsResponse
 }
 
 export const deleteCredentials = async (
@@ -103,14 +99,11 @@ export const deleteCredentials = async (
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'DELETE',
+    operation: 'delete credentials',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return response.statusCode
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return response.statusCode
 }
 
 export const updateCredentials = async (
@@ -134,14 +127,11 @@ export const updateCredentials = async (
     headers: headers,
     method: 'PATCH',
     body: JSON.stringify(body),
+    operation: 'update credentials',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return response.body
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return response.body
 }
 
 export const convertCredsToUuid = async (

--- a/src/api/credentials.ts
+++ b/src/api/credentials.ts
@@ -2,7 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
-import {NotFoundError} from '../utils/api-error.js'
+import {ApiError} from '../utils/errors.js'
 import {createLogger} from '../utils/logger.js'
 import {
   CredentialsAttributes,
@@ -30,7 +30,7 @@ export const getCredentialsForDeployment = async (tenantId: string, installId: s
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as CredentialsListResponse
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ApiError && error.statusCode === 404) {
       return {data: [], jsonapi: {version: ''}, links: {}}
     }
     throw error

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -2,7 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
-import {NotFoundError} from '../utils/api-error.js'
+import {ApiError} from '../utils/errors.js'
 import {createLogger} from '../utils/logger.js'
 
 const logger = createLogger()
@@ -57,7 +57,7 @@ export const getDeployments = async (tenantId: string, installId: string) => {
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as DeploymentsResponse
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ApiError && error.statusCode === 404) {
       return {data: [], errors: [{details: '404'}]}
     }
     throw error

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -2,6 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
+import {NotFoundError} from '../utils/api-error.js'
 import {createLogger} from '../utils/logger.js'
 
 const logger = createLogger()
@@ -49,16 +50,18 @@ export const getDeployments = async (tenantId: string, installId: string) => {
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'list deployments',
   }
-  const response = await makeRequest(req)
-  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-  if (response.statusCode && response.statusCode === 404) {
-    return {data: [], errors: [{details: '404'}]}
+  try {
+    const response = await makeRequest(req)
+    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+    return JSON.parse(response.body) as DeploymentsResponse
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return {data: [], errors: [{details: '404'}]}
+    }
+    throw error
   }
-  if (response.statusCode && response.statusCode > 299) {
-    throw new Error(`${response.statusCode} - ${response.statusText ?? ''}`)
-  }
-  return JSON.parse(response.body) as DeploymentsResponse
 }
 
 export const createDeployment = async (
@@ -82,14 +85,11 @@ export const createDeployment = async (
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'create the deployment',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as DeploymentResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as DeploymentResponse
 }
 
 export const deleteDeployment = async (tenantId: string, installId: string, deploymentId: string) => {
@@ -101,6 +101,7 @@ export const deleteDeployment = async (tenantId: string, installId: string, depl
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'DELETE',
+    operation: 'delete the deployment',
   }
   const response = await makeRequest(req)
   logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
@@ -133,6 +134,7 @@ export const updateDeployment = async (
     headers: headers,
     method: 'PATCH',
     body: JSON.stringify(body),
+    operation: 'update the deployment',
   }
   const response = await makeRequest(req)
   logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')

--- a/src/api/integrations.ts
+++ b/src/api/integrations.ts
@@ -2,6 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
+import {NotFoundError} from '../utils/api-error.js'
 import {createLogger} from '../utils/logger.js'
 import {getDummyCredentialsForIntegrationType} from './integrations-utils.js'
 import {IntegrationResponse, IntegrationsResponse} from './types.js'
@@ -23,13 +24,17 @@ export const getIntegrationsForConnection = async (tenantId: string, connectionI
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'list integrations',
   }
   try {
     const response = await makeRequest(req)
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as IntegrationsResponse
-  } catch (error: any) {
-    throw new Error(error)
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return {data: [], jsonapi: {version: ''}, links: {}}
+    }
+    throw error
   }
 }
 
@@ -47,14 +52,11 @@ export const deleteIntegrationsForConnection = async (
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION}`,
     headers: headers,
     method: 'DELETE',
+    operation: 'delete the integration',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return response.statusCode
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return response.statusCode
 }
 
 export const createIntegrationForConnection = async (
@@ -81,14 +83,11 @@ export const createIntegrationForConnection = async (
     headers: headers,
     method: 'POST',
     body: JSON.stringify(body),
+    operation: 'create the integration',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as IntegrationResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as IntegrationResponse
 }
 
 export const disconnectIntegrationForOrgIdAndIntegrationId = async (
@@ -118,14 +117,8 @@ export const disconnectIntegrationForOrgIdAndIntegrationId = async (
     headers: headers,
     method: 'PUT',
     body: body,
+    operation: 'disconnect the integration',
   }
-  try {
-    const response = await makeRequest(req)
-    if (response.statusCode && response.statusCode > 299) {
-      throw new Error(`Error Disabling brokered integration ${integrationId} - ${response.statusCode}:${response.body}`)
-    }
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
 }

--- a/src/api/integrations.ts
+++ b/src/api/integrations.ts
@@ -2,7 +2,7 @@ import {getCommonHeaders} from '../common/rest-helpers.js'
 import {getConfig} from '../config/config.js'
 import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
-import {NotFoundError} from '../utils/api-error.js'
+import {ApiError} from '../utils/errors.js'
 import {createLogger} from '../utils/logger.js'
 import {getDummyCredentialsForIntegrationType} from './integrations-utils.js'
 import {IntegrationResponse, IntegrationsResponse} from './types.js'
@@ -31,7 +31,7 @@ export const getIntegrationsForConnection = async (tenantId: string, connectionI
     logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
     return JSON.parse(response.body) as IntegrationsResponse
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ApiError && error.statusCode === 404) {
       return {data: [], jsonapi: {version: ''}, links: {}}
     }
     throw error

--- a/src/api/snyk.ts
+++ b/src/api/snyk.ts
@@ -34,19 +34,11 @@ export const validateSnykToken = async (snykToken: string): Promise<string> => {
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.APP_INSTALL_API_VERSION}`,
     headers: headers,
     method: 'GET',
+    operation: 'validate the Snyk token',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
 
-    const parsedResponse = JSON.parse(response.body) as SelfResponse
-    return parsedResponse.data.id
-  } catch (error: any) {
-    let errorMessage = error
-    if (error.includes('401: Unauthorized.')) {
-      errorMessage = `Invalid/stale token? Are you using the right region? (using ${config.API_HOSTNAME}).`
-      logger.error({error}, 'Error validating Snyk Token.')
-    }
-    throw new Error(errorMessage)
-  }
+  const parsedResponse = JSON.parse(response.body) as SelfResponse
+  return parsedResponse.data.id
 }

--- a/src/api/snyk.ts
+++ b/src/api/snyk.ts
@@ -4,6 +4,7 @@ import {getAuthHeader} from '../utils/auth.js'
 import {HttpRequest, makeRequest} from '../utils/http-request.js'
 import {isValidUUID} from '../utils/validation.js'
 import {createLogger} from '../utils/logger.js'
+import {ApiError} from '../utils/errors.js'
 
 const logger = createLogger()
 
@@ -36,9 +37,16 @@ export const validateSnykToken = async (snykToken: string): Promise<string> => {
     method: 'GET',
     operation: 'validate the Snyk token',
   }
-  const response = await makeRequest(req)
-  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  try {
+    const response = await makeRequest(req)
+    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
 
-  const parsedResponse = JSON.parse(response.body) as SelfResponse
-  return parsedResponse.data.id
+    const parsedResponse = JSON.parse(response.body) as SelfResponse
+    return parsedResponse.data.id
+  } catch (error) {
+    if (error instanceof ApiError && error.statusCode === 401) {
+      throw new Error(`Invalid/stale token? Are you using the right region? (using ${config.API_HOSTNAME}).`)
+    }
+    throw error
+  }
 }

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -38,14 +38,11 @@ export const getAccessibleTenants = async () => {
     url: `${config.API_HOSTNAME}/${apiPath}?version=${config.API_VERSION_TENANTS}`,
     headers: headers,
     method: 'GET',
+    operation: 'list accessible tenants',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
-    return JSON.parse(response.body) as TenantsListingResponse
-  } catch (error: any) {
-    throw new Error(error)
-  }
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  return JSON.parse(response.body) as TenantsListingResponse
 }
 
 interface TenantMembership {
@@ -109,16 +106,13 @@ export const isTenantAdmin = async (tenantId: string, userId: string) => {
     url: url.toString(),
     headers: headers,
     method: 'GET',
+    operation: 'verify tenant admin role',
   }
-  try {
-    const response = await makeRequest(req)
-    logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
+  const response = await makeRequest(req)
+  logger.debug({url: req.url, statusCode: response.statusCode, response: response.body}, 'Response')
 
-    const parsedResponse = JSON.parse(response.body) as TenantsMembershipResponse
-    if (parsedResponse.data.length === 0) {
-      throw new Error(`User ${userId} does not have the required permission.`)
-    }
-  } catch (error: any) {
-    throw new Error(error)
+  const parsedResponse = JSON.parse(response.body) as TenantsMembershipResponse
+  if (parsedResponse.data.length === 0) {
+    throw new Error(`User ${userId} does not have the required permission.`)
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -20,7 +20,7 @@ import {getAccessibleTenants, isTenantAdmin} from './api/tenants.js'
 import {validatedInput, ValidationType} from './utils/input-validation.js'
 import {validateSnykToken} from './api/snyk.js'
 import {getContextsForForDeployment} from './api/contexts.js'
-import {ApiError} from './utils/api-error.js'
+import {ApiError, NetworkError} from './utils/errors.js'
 import {STATUS} from './utils/display.js'
 
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<(typeof BaseCommand)['baseFlags'] & T['flags']>
@@ -121,7 +121,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       this.logStatus(ux.colorize('green', `${STATUS.OK} Tenant Admin role confirmed.`))
     } catch (error) {
       this.debug(error)
-      if (error instanceof ApiError) {
+      if (error instanceof ApiError || error instanceof NetworkError) {
         this.error(error.message)
       } else {
         this.error(

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -20,6 +20,7 @@ import {getAccessibleTenants, isTenantAdmin} from './api/tenants.js'
 import {validatedInput, ValidationType} from './utils/input-validation.js'
 import {validateSnykToken} from './api/snyk.js'
 import {getContextsForForDeployment} from './api/contexts.js'
+import {ApiError} from './utils/api-error.js'
 import {STATUS} from './utils/display.js'
 
 export type Flags<T extends typeof Command> = Interfaces.InferredFlags<(typeof BaseCommand)['baseFlags'] & T['flags']>
@@ -82,7 +83,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       userId = await validateSnykToken(process.env.SNYK_TOKEN)
       this.logStatus(ux.colorize('green', `${STATUS.OK} Valid Snyk Token for user ${userId}.`))
     } catch (error) {
-      this.error(`Invalid Snyk Token. ${error}`)
+      this.error(error instanceof Error ? error.message : String(error))
     }
     if (!process.env.TENANT_ID) {
       const accessibleTenants = await getAccessibleTenants()
@@ -120,9 +121,13 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       this.logStatus(ux.colorize('green', `${STATUS.OK} Tenant Admin role confirmed.`))
     } catch (error) {
       this.debug(error)
-      this.error(
-        `This tool requires Tenant Admin role. Please use a Tenant level Admin account or upgrade your account to be Tenant Admin.`,
-      )
+      if (error instanceof ApiError) {
+        this.error(error.message)
+      } else {
+        this.error(
+          `This tool requires Tenant Admin role. Please use a Tenant level Admin account or upgrade your account to be Tenant Admin.`,
+        )
+      }
     }
 
     let orgId

--- a/src/commands/bulk-migration/apply.ts
+++ b/src/commands/bulk-migration/apply.ts
@@ -66,7 +66,7 @@ export default class BulkMigrationApply extends BaseCommand<typeof BulkMigration
       this.log(printFormattedJSON(bulkMigrationResponse.data))
       return bulkMigrationResponse.data
     } catch (error) {
-      this.error(`\nFailed to start bulk migration: ${(error as Error).message}`, {exit: 1})
+      this.error(`\n${error instanceof Error ? error.message : String(error)}`, {exit: 1})
     }
   }
 }

--- a/src/commands/workflows/bulk-migration/apply.ts
+++ b/src/commands/workflows/bulk-migration/apply.ts
@@ -50,7 +50,7 @@ export default class BulkMigrationApply extends BaseCommand<typeof BulkMigration
       this.log(printFormattedJSON(bulkMigrationResponse.data))
       return bulkMigrationResponse.data
     } catch (error) {
-      this.error(`\nFailed to start bulk migration: ${(error as Error).message}`)
+      this.error(`\n${error instanceof Error ? error.message : String(error)}`)
     }
   }
 }

--- a/src/utils/api-error.ts
+++ b/src/utils/api-error.ts
@@ -1,0 +1,97 @@
+import type {HttpRequest, HttpResponse} from './http-request.js'
+
+const MAX_RAW_DETAIL_LENGTH = 500
+
+export interface ApiErrorFields {
+  statusCode: number | undefined
+  statusText: string
+  requestId: string
+  detail: string
+  url: string
+  method: string
+  interactionId: string
+  operation: string
+}
+
+export class ApiError extends Error {
+  readonly statusCode: number | undefined
+  readonly requestId: string
+  readonly detail: string
+  readonly url: string
+  readonly method: string
+  readonly interactionId: string
+  readonly operation: string
+
+  constructor(fields: ApiErrorFields) {
+    const prefix = fields.operation ? `Failed to ${fields.operation}.\n` : ''
+    super(
+      `${prefix}${fields.statusCode}: ${fields.statusText}.\n\n` +
+        `- Url: (${fields.method})${fields.url}.\n` +
+        `- requestId: ${fields.requestId}\n` +
+        `- interactionId: ${fields.interactionId}\n\n` +
+        `- ${fields.detail}`,
+    )
+    this.name = 'ApiError'
+    this.statusCode = fields.statusCode
+    this.requestId = fields.requestId
+    this.detail = fields.detail
+    this.url = fields.url
+    this.method = fields.method
+    this.interactionId = fields.interactionId
+    this.operation = fields.operation
+  }
+}
+
+// A 404 response. Collection lookups treat this as "none exist"; specific-id
+// lookups let it surface as a failure like any other ApiError.
+export class NotFoundError extends ApiError {
+  constructor(fields: ApiErrorFields) {
+    super(fields)
+    this.name = 'NotFoundError'
+  }
+}
+
+// Builds a structured ApiError from a failed response, resolving the request id
+// from the server's snyk-request-id header, then the JSON:API errors[].id, then
+// the client-generated fallback. The body is parsed defensively so a non-JSON
+// error payload never masks the status code.
+export const buildApiError = (
+  response: Pick<HttpResponse, 'headers' | 'statusCode' | 'statusText'>,
+  body: string,
+  req: Pick<HttpRequest, 'method' | 'url' | 'operation'>,
+  fallbackRequestId: string,
+  interactionId: string,
+): ApiError => {
+  const headers = (response.headers ?? {}) as Record<string, string | string[] | undefined>
+  const headerRequestId = headers['snyk-request-id']
+
+  let bodyRequestId: string | undefined
+  let detail: string | undefined
+
+  try {
+    const parsed = JSON.parse(body)
+    const errors = (parsed?.errors as Array<{id?: string; detail?: string; details?: string}>) ?? []
+    bodyRequestId = errors.find((error) => error.id)?.id
+    detail = errors
+      .map((error) => error.detail ?? error.details)
+      .filter(Boolean)
+      .join('; ')
+  } catch {
+    detail = body?.trim().slice(0, MAX_RAW_DETAIL_LENGTH)
+  }
+
+  const requestId =
+    (Array.isArray(headerRequestId) ? headerRequestId[0] : headerRequestId) ?? bodyRequestId ?? fallbackRequestId
+
+  const ErrorClass = response.statusCode === 404 ? NotFoundError : ApiError
+  return new ErrorClass({
+    statusCode: response.statusCode,
+    statusText: response.statusText || '',
+    requestId,
+    detail: detail || response.statusText || '',
+    url: req.url,
+    method: req.method,
+    interactionId,
+    operation: req.operation ?? '',
+  })
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,7 +1,5 @@
 import type {HttpRequest, HttpResponse} from './http-request.js'
 
-const MAX_RAW_DETAIL_LENGTH = 500
-
 export interface ApiErrorFields {
   statusCode: number | undefined
   statusText: string
@@ -42,13 +40,62 @@ export class ApiError extends Error {
   }
 }
 
-// A 404 response. Collection lookups treat this as "none exist"; specific-id
-// lookups let it surface as a failure like any other ApiError.
-export class NotFoundError extends ApiError {
-  constructor(fields: ApiErrorFields) {
-    super(fields)
-    this.name = 'NotFoundError'
+export interface NetworkErrorFields {
+  operation: string
+  interactionId: string
+  code: string
+  message: string
+}
+
+// A transport failure where no HTTP response was received (connection refused,
+// DNS, timeout, TLS/cert errors). No server status, url, or request id applies.
+export class NetworkError extends Error {
+  readonly operation: string
+  readonly interactionId: string
+  readonly code: string
+
+  constructor(fields: NetworkErrorFields) {
+    const prefix = fields.operation ? `Failed to ${fields.operation}.\n` : ''
+    const detail = fields.code ? `${fields.code}: ${fields.message}` : fields.message
+    super(`${prefix}- interactionId: ${fields.interactionId}\n\n- ${detail}`)
+    this.name = 'NetworkError'
+    this.operation = fields.operation
+    this.interactionId = fields.interactionId
+    this.code = fields.code
   }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error !== null && typeof error === 'object' && 'message' in error
+}
+
+// Builds a NetworkError from a transport-level failure, carrying the failing
+// operation and interaction id plus the raw underlying error code and message.
+// The Node error code (e.g. ECONNREFUSED, SELF_SIGNED_CERT_IN_CHAIN) is captured
+// explicitly because it is often absent from the message text.
+export const buildNetworkError = (
+  req: Pick<HttpRequest, 'operation'>,
+  interactionId: string,
+  error: unknown,
+): Error => {
+  if (!isNodeError(error)) {
+    return new Error(String(error))
+  }
+  return new NetworkError({
+    operation: req.operation ?? '',
+    interactionId,
+    code: error.code ?? '',
+    message: error.message,
+  })
+}
+// The JSON:API error body the Snyk backend returns on a failed request, e.g.
+// {"errors":[{"detail":"Permission denied","status":"403"}],"jsonapi":{"version":"1.0"}}.
+interface ApiErrorBody {
+  errors?: Array<{id?: string; detail?: string; status?: string}>
+}
+
+function isApiErrorBody(value: unknown): value is ApiErrorBody {
+  return typeof value === 'object' && value !== null && (!('errors' in value) || Array.isArray(value.errors))
 }
 
 // Builds a structured ApiError from a failed response, resolving the request id
@@ -69,22 +116,22 @@ export const buildApiError = (
   let detail: string | undefined
 
   try {
-    const parsed = JSON.parse(body)
-    const errors = (parsed?.errors as Array<{id?: string; detail?: string; details?: string}>) ?? []
+    const parsed: unknown = JSON.parse(body)
+    const errors = isApiErrorBody(parsed) ? (parsed.errors ?? []) : []
     bodyRequestId = errors.find((error) => error.id)?.id
     detail = errors
-      .map((error) => error.detail ?? error.details)
+      .map((error) => error.detail)
       .filter(Boolean)
       .join('; ')
   } catch {
-    detail = body?.trim().slice(0, MAX_RAW_DETAIL_LENGTH)
+    // if not JSON, use the body
+    detail = body?.trim()
   }
 
   const requestId =
     (Array.isArray(headerRequestId) ? headerRequestId[0] : headerRequestId) ?? bodyRequestId ?? fallbackRequestId
 
-  const ErrorClass = response.statusCode === 404 ? NotFoundError : ApiError
-  return new ErrorClass({
+  return new ApiError({
     statusCode: response.statusCode,
     statusText: response.statusText || '',
     requestId,

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -3,12 +3,15 @@ import http from 'node:http'
 import https from 'node:https'
 import {getProxyForUrl} from 'proxy-from-env'
 import {bootstrap} from 'global-agent'
+import {buildApiError} from './api-error.js'
 
 export interface HttpRequest {
   url: string
   headers: Object
   method: string
   body?: string | Buffer | Uint8Array
+  // Human-readable operation for error output, e.g. "create the connection".
+  operation?: string
 }
 
 export interface HttpResponse {
@@ -60,11 +63,17 @@ export const makeRequest = async (req: HttpRequest, retries = MAX_RETRY): Promis
 
         // The whole response has been received.
         response.on('end', () => {
-          if (response.statusCode && response.statusCode > 299 && response.statusCode !== 404) {
-            const errors = (JSON.parse(data).errors as Array<any>) ?? ''
+          if (response.statusCode && response.statusCode > 299) {
             reject(
-              `${response.statusCode}: ${response.statusMessage}.\n\n- Url: (${req.method})${req.url}.\n- requestId: ${requestId}\n- interactionId: ${interactionId}\n\n- ${errors.map((error) => error.detail).join(';')}`,
+              buildApiError(
+                {headers: response.headers, statusCode: response.statusCode, statusText: response.statusMessage || ''},
+                data,
+                req,
+                requestId,
+                interactionId,
+              ),
             )
+            return
           }
           resolve({
             headers: response.headers,

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -3,7 +3,7 @@ import http from 'node:http'
 import https from 'node:https'
 import {getProxyForUrl} from 'proxy-from-env'
 import {bootstrap} from 'global-agent'
-import {buildApiError} from './api-error.js'
+import {buildApiError, buildNetworkError} from './errors.js'
 
 export interface HttpRequest {
   url: string
@@ -97,20 +97,20 @@ export const makeRequest = async (req: HttpRequest, retries = MAX_RETRY): Promis
               {error, requestId, interactionId},
               `Error getting response from downstream. Giving up after ${MAX_RETRY} retries.`,
             )
-            reject(error)
+            reject(buildNetworkError(req, interactionId, error))
           }
         })
       })
       request.on('error', (error) => {
         console.error({error, requestId, interactionId}, 'Error making request to downstream.')
-        reject(error)
+        reject(buildNetworkError(req, interactionId, error))
       })
       if (localRequest.body) {
         request.write(localRequest.body)
       }
       request.end()
     } catch (error) {
-      reject(error)
+      reject(buildNetworkError(req, interactionId, error))
     }
   })
 }

--- a/test/utils/http-request.test.ts
+++ b/test/utils/http-request.test.ts
@@ -1,5 +1,5 @@
 import {makeRequest, HttpRequest} from '../../src/utils/http-request'
-import {ApiError} from '../../src/utils/api-error'
+import {ApiError, NetworkError} from '../../src/utils/errors'
 import {expect} from 'chai'
 import nock from 'nock'
 
@@ -111,19 +111,6 @@ describe('makeRequest error handling', () => {
     }
   })
 
-  it('captures the detail when the body uses the "details" spelling', async () => {
-    nock('https://example.com')
-      .get('/test')
-      .reply(401, {jsonapi: {version: '1.0'}, errors: [{status: '401', details: 'Unauthorized'}]})
-
-    try {
-      await makeRequest(errorRequest(), 0)
-      expect.fail('expected makeRequest to reject')
-    } catch (error) {
-      expect((error as ApiError).detail).to.equal('Unauthorized')
-    }
-  })
-
   it('prefixes the error message with the failing operation when one is set', async () => {
     nock('https://example.com')
       .get('/test')
@@ -136,6 +123,39 @@ describe('makeRequest error handling', () => {
       const apiError = error as ApiError
       expect(apiError.operation).to.equal('create the connection')
       expect(apiError.message).to.contain('Failed to create the connection.')
+    }
+  })
+
+  it('rejects with a NetworkError carrying the operation, code and raw message when the transport fails', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .replyWithError({code: 'ECONNREFUSED', message: 'connect ECONNREFUSED 127.0.0.1:443'})
+
+    try {
+      await makeRequest({...errorRequest(), operation: 'list connections'}, 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      expect(error).to.be.instanceOf(NetworkError)
+      const networkError = error as NetworkError
+      expect(networkError.operation).to.equal('list connections')
+      expect(networkError.code).to.equal('ECONNREFUSED')
+      expect(networkError.message).to.contain('Failed to list connections.')
+      expect(networkError.message).to.contain('ECONNREFUSED: connect ECONNREFUSED')
+    }
+  })
+
+  it('surfaces a TLS/cert error code even when the message omits it', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .replyWithError({code: 'SELF_SIGNED_CERT_IN_CHAIN', message: 'self signed certificate in certificate chain'})
+
+    try {
+      await makeRequest({...errorRequest(), operation: 'list connections'}, 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      const networkError = error as NetworkError
+      expect(networkError.code).to.equal('SELF_SIGNED_CERT_IN_CHAIN')
+      expect(networkError.message).to.contain('SELF_SIGNED_CERT_IN_CHAIN')
     }
   })
 

--- a/test/utils/http-request.test.ts
+++ b/test/utils/http-request.test.ts
@@ -1,4 +1,5 @@
 import {makeRequest, HttpRequest} from '../../src/utils/http-request'
+import {ApiError} from '../../src/utils/api-error'
 import {expect} from 'chai'
 import nock from 'nock'
 
@@ -60,5 +61,95 @@ describe('makeRequest SNYK-REQUEST-ID injection', () => {
     await makeRequest(req, 0)
     const id = (req.headers as Record<string, string>)['SNYK-REQUEST-ID']
     expect(id).to.equal(existingId)
+  })
+})
+
+describe('makeRequest error handling', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  const errorRequest = (): HttpRequest => ({
+    url: 'https://example.com/test',
+    headers: {'Content-Type': 'application/json'},
+    method: 'GET',
+  })
+
+  it('rejects with an ApiError carrying status, detail and the server request id from the header', async () => {
+    const serverRequestId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    nock('https://example.com')
+      .get('/test')
+      .reply(400, {errors: [{id: 'body-id', detail: 'Unknown query parameter'}]}, {'snyk-request-id': serverRequestId})
+
+    try {
+      await makeRequest(errorRequest(), 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      expect(error).to.be.instanceOf(ApiError)
+      const apiError = error as ApiError
+      expect(apiError.statusCode).to.equal(400)
+      expect(apiError.requestId).to.equal(serverRequestId)
+      expect(apiError.detail).to.equal('Unknown query parameter')
+      expect(apiError.message).to.contain('400')
+      expect(apiError.message).to.contain('Unknown query parameter')
+      expect(apiError.message).to.contain(serverRequestId)
+    }
+  })
+
+  it('falls back to errors[].id when no snyk-request-id header is present', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(403, {errors: [{id: 'body-request-id', detail: 'Forbidden'}]})
+
+    try {
+      await makeRequest(errorRequest(), 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      const apiError = error as ApiError
+      expect(apiError.requestId).to.equal('body-request-id')
+      expect(apiError.detail).to.equal('Forbidden')
+    }
+  })
+
+  it('captures the detail when the body uses the "details" spelling', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(401, {jsonapi: {version: '1.0'}, errors: [{status: '401', details: 'Unauthorized'}]})
+
+    try {
+      await makeRequest(errorRequest(), 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      expect((error as ApiError).detail).to.equal('Unauthorized')
+    }
+  })
+
+  it('prefixes the error message with the failing operation when one is set', async () => {
+    nock('https://example.com')
+      .get('/test')
+      .reply(400, {errors: [{detail: 'Unknown query parameter'}]})
+
+    try {
+      await makeRequest({...errorRequest(), operation: 'create the connection'}, 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      const apiError = error as ApiError
+      expect(apiError.operation).to.equal('create the connection')
+      expect(apiError.message).to.contain('Failed to create the connection.')
+    }
+  })
+
+  it('does not throw on a non-JSON error body and still reports the status code', async () => {
+    nock('https://example.com').get('/test').reply(502, '<html>Bad Gateway</html>')
+
+    try {
+      await makeRequest(errorRequest(), 0)
+      expect.fail('expected makeRequest to reject')
+    } catch (error) {
+      expect(error).to.be.instanceOf(ApiError)
+      const apiError = error as ApiError
+      expect(apiError.statusCode).to.equal(502)
+      expect(apiError.detail).to.contain('Bad Gateway')
+    }
   })
 })


### PR DESCRIPTION
Replace ad-hoc per-call try/catch and error-string parsing across the API layer and network layer with shared error types, so callers surface consistent, structured error details.